### PR TITLE
Add an empty type

### DIFF
--- a/Definition/Conversion.agda
+++ b/Definition/Conversion.agda
@@ -35,6 +35,10 @@ mutual
                 → Γ ⊢ h [conv↑] g ∷ Π ℕ ▹ (F ▹▹ F [ suc (var 0) ]↑)
                 → Γ ⊢ k ~ l ↓ ℕ
                 → Γ ⊢ natrec F a₀ h k ~ natrec G b₀ g l ↑ F [ k ]
+    Emptyrec-cong : ∀ {k l F G}
+                  → Γ ⊢ F [conv↑] G
+                  → Γ ⊢ k ~ l ↓ Empty
+                  → Γ ⊢ Emptyrec F k ~ Emptyrec G l ↑ F
 
   -- Neutral equality with types in WHNF.
   record _⊢_~_↓_ (Γ : Con Term) (k l B : Term) : Set where
@@ -62,6 +66,7 @@ mutual
   data _⊢_[conv↓]_ (Γ : Con Term) : (A B : Term) → Set where
     U-refl    : ⊢ Γ → Γ ⊢ U [conv↓] U
     ℕ-refl    : ⊢ Γ → Γ ⊢ ℕ [conv↓] ℕ
+    Empty-refl : ⊢ Γ → Γ ⊢ Empty [conv↓] Empty
     ne        : ∀ {K L}
               → Γ ⊢ K ~ L ↓ U
               → Γ ⊢ K [conv↓] L
@@ -90,6 +95,9 @@ mutual
     ℕ-ins     : ∀ {k l}
               → Γ ⊢ k ~ l ↓ ℕ
               → Γ ⊢ k [conv↓] l ∷ ℕ
+    Empty-ins : ∀ {k l}
+              → Γ ⊢ k ~ l ↓ Empty
+              → Γ ⊢ k [conv↓] l ∷ Empty
     ne-ins    : ∀ {k l M N}
               → Γ ⊢ k ∷ N
               → Γ ⊢ l ∷ N

--- a/Definition/Conversion/Conversion.agda
+++ b/Definition/Conversion/Conversion.agda
@@ -42,6 +42,8 @@ mutual
                 → Δ ⊢ t [conv↓] u ∷ B
   convConv↓Term Γ≡Δ A≡B whnfB (ℕ-ins x) rewrite ℕ≡A A≡B whnfB =
     ℕ-ins (stability~↓ Γ≡Δ x)
+  convConv↓Term Γ≡Δ A≡B whnfB (Empty-ins x) rewrite Empty≡A A≡B whnfB =
+    Empty-ins (stability~↓ Γ≡Δ x)
   convConv↓Term Γ≡Δ A≡B whnfB (ne-ins t u x x₁) with ne≡A x A≡B whnfB
   convConv↓Term Γ≡Δ A≡B whnfB (ne-ins t u x x₁) | B , neB , PE.refl =
     ne-ins (stabilityTerm Γ≡Δ (conv t A≡B)) (stabilityTerm Γ≡Δ (conv u A≡B))

--- a/Definition/Conversion/EqRelInstance.agda
+++ b/Definition/Conversion/EqRelInstance.agda
@@ -74,6 +74,22 @@ data _⊢_~_∷_ (Γ : Con Term) (k l A : Term) : Set where
   in  ↑ (refl (substType ⊢F ⊢n))
         (natrec-cong x x₁ x₂ k~l′)
 
+~-Emptyrec : ∀ {n n′ F F′ Γ}
+         → Γ ⊢ F [conv↑] F′ →
+      Γ ⊢ n ~ n′ ∷ Empty →
+      Γ ⊢ Emptyrec F n ~ Emptyrec F′ n′ ∷ F
+~-Emptyrec x (↑ A≡B x₄) =
+  let _ , ⊢B = syntacticEq A≡B
+      B′ , whnfB′ , D = whNorm ⊢B
+      Empty≡B′ = trans A≡B (subset* (red D))
+      B≡Empty = Empty≡A Empty≡B′ whnfB′
+      k~l′ = PE.subst (λ x → _ ⊢ _ ~ _ ↓ x) B≡Empty
+                      ([~] _ (red D) whnfB′ x₄)
+      ⊢F , _ = syntacticEq (soundnessConv↑ x)
+      _ , ⊢n , _ = syntacticEqTerm (soundness~↓ k~l′)
+  in  ↑ (refl ⊢F)
+        (Emptyrec-cong x k~l′)
+
 ~-sym : {k l A : Term} {Γ : Con Term} → Γ ⊢ k ~ l ∷ A → Γ ⊢ l ~ k ∷ A
 ~-sym (↑ A≡B x) =
   let ⊢Γ = wfEq A≡B
@@ -115,6 +131,8 @@ eqRelInstance = eqRel _⊢_[conv↑]_ _⊢_[conv↑]_∷_ _⊢_~_∷_
                       (liftConv ∘ᶠ U-refl)
                       (liftConv ∘ᶠ ℕ-refl)
                       (λ x → liftConvTerm (univ (ℕⱼ x) (ℕⱼ x) (ℕ-refl x)))
+                      (liftConv ∘ᶠ Empty-refl)
+                      (λ x → liftConvTerm (univ (Emptyⱼ x) (Emptyⱼ x) (Empty-refl x)))
                       (λ x x₁ x₂ → liftConv (Π-cong x x₁ x₂))
                       (λ x x₁ x₂ →
                          let _ , F∷U , H∷U = syntacticEqTerm (soundnessConv↑Term x₁)
@@ -130,4 +148,4 @@ eqRelInstance = eqRel _⊢_[conv↑]_ _⊢_[conv↑]_∷_ _⊢_~_∷_
                       (liftConvTerm ∘ᶠ zero-refl)
                       (liftConvTerm ∘ᶠ suc-cong)
                       (λ x x₁ x₂ x₃ x₄ x₅ → liftConvTerm (η-eq x x₁ x₂ x₃ x₄ x₅))
-                      ~-var ~-app ~-natrec
+                      ~-var ~-app ~-natrec ~-Emptyrec

--- a/Definition/Conversion/FullReduction.agda
+++ b/Definition/Conversion/FullReduction.agda
@@ -23,12 +23,15 @@ mutual
     ∘ₙ      : ∀ {k u}     → NfNeutral k → Nf u → NfNeutral (k ∘ u)
     natrecₙ : ∀ {C c g k} → Nf C → Nf c → Nf g → NfNeutral k
                                                → NfNeutral (natrec C c g k)
+    Emptyrecₙ : ∀ {C k} → Nf C → NfNeutral k
+                               → NfNeutral (Emptyrec C k)
 
   data Nf : Term → Set where
 
     Uₙ    : Nf U
     Πₙ    : ∀ {A B} → Nf A → Nf B → Nf (Π A ▹ B)
     ℕₙ    : Nf ℕ
+    Emptyₙ    : Nf Empty
 
     lamₙ  : ∀ {t} → Nf t → Nf (lam t)
     zeroₙ : Nf zero
@@ -51,6 +54,11 @@ mutual
         n′ , nfN′ , n≡n′ = fullRedNe′ n
     in  natrec C′ z′ s′ n′ , natrecₙ nfC′ nfZ′ nfS′ nfN′
      ,  natrec-cong C≡C′ z≡z′ s≡s′ n≡n′
+  fullRedNe (Emptyrec-cong C n) =
+    let C′ , nfC′ , C≡C′ = fullRed C
+        n′ , nfN′ , n≡n′ = fullRedNe′ n
+    in  Emptyrec C′ n′ , Emptyrecₙ nfC′ nfN′
+     ,  Emptyrec-cong C≡C′ n≡n′
 
   fullRedNe′ : ∀ {t A Γ} → Γ ⊢ t ~ t ↓ A → ∃ λ u → NfNeutral u × Γ ⊢ t ≡ u ∷ A
   fullRedNe′ ([~] A D whnfB k~l) =
@@ -66,6 +74,7 @@ mutual
   fullRed′ : ∀ {A Γ} → Γ ⊢ A [conv↓] A → ∃ λ B → Nf B × Γ ⊢ A ≡ B
   fullRed′ (U-refl ⊢Γ) = U , Uₙ , refl (Uⱼ ⊢Γ)
   fullRed′ (ℕ-refl ⊢Γ) = ℕ , ℕₙ , refl (ℕⱼ ⊢Γ)
+  fullRed′ (Empty-refl ⊢Γ) = Empty , Emptyₙ , refl (Emptyⱼ ⊢Γ)
   fullRed′ (ne A) =
     let B , nf , A≡B = fullRedNe′ A
     in  B , ne nf , univ A≡B
@@ -82,6 +91,9 @@ mutual
 
   fullRedTerm′ : ∀ {t A Γ} → Γ ⊢ t [conv↓] t ∷ A → ∃ λ u → Nf u × Γ ⊢ t ≡ u ∷ A
   fullRedTerm′ (ℕ-ins t) =
+    let u , nf , t≡u = fullRedNe′ t
+    in  u , ne nf , t≡u
+  fullRedTerm′ (Empty-ins t) =
     let u , nf , t≡u = fullRedNe′ t
     in  u , ne nf , t≡u
   fullRedTerm′ (ne-ins ⊢t _ _ t) =

--- a/Definition/Conversion/Lift.agda
+++ b/Definition/Conversion/Lift.agda
@@ -55,6 +55,9 @@ mutual
   lift~toConv↓′ (ℕᵣ D) D₁ ([~] A D₂ whnfB k~l)
                 rewrite PE.sym (whrDet* (red D , ℕₙ) (D₁ , whnfB)) =
     ℕ-ins ([~] A D₂ ℕₙ k~l)
+  lift~toConv↓′ (Emptyᵣ D) D₁ ([~] A D₂ whnfB k~l)
+                rewrite PE.sym (whrDet* (red D , Emptyₙ) (D₁ , whnfB)) =
+    Empty-ins ([~] A D₂ Emptyₙ k~l)
   lift~toConv↓′ (ne′ K D neK K≡K) D₁ ([~] A D₂ whnfB k~l)
                 rewrite PE.sym (whrDet* (red D , ne neK) (D₁ , whnfB)) =
     let _ , ⊢t , ⊢u = syntacticEqTerm (soundness~↑ k~l)

--- a/Definition/Conversion/Soundness.agda
+++ b/Definition/Conversion/Soundness.agda
@@ -23,6 +23,8 @@ mutual
   soundness~↑ (natrec-cong x₁ x₂ x₃ k~l) =
     natrec-cong (soundnessConv↑ x₁) (soundnessConv↑Term x₂)
                 (soundnessConv↑Term x₃) (soundness~↓ k~l)
+  soundness~↑ (Emptyrec-cong x₁ k~l) =
+    Emptyrec-cong (soundnessConv↑ x₁) (soundness~↓ k~l)
 
   -- Algorithmic equality of neutrals in WHNF is well-formed.
   soundness~↓ : ∀ {k l A Γ} → Γ ⊢ k ~ l ↓ A → Γ ⊢ k ≡ l ∷ A
@@ -37,6 +39,7 @@ mutual
   soundnessConv↓ : ∀ {A B Γ} → Γ ⊢ A [conv↓] B → Γ ⊢ A ≡ B
   soundnessConv↓ (U-refl ⊢Γ) = refl (Uⱼ ⊢Γ)
   soundnessConv↓ (ℕ-refl ⊢Γ) = refl (ℕⱼ ⊢Γ)
+  soundnessConv↓ (Empty-refl ⊢Γ) = refl (Emptyⱼ ⊢Γ)
   soundnessConv↓ (ne x) = univ (soundness~↓ x)
   soundnessConv↓ (Π-cong F c c₁) =
     Π-cong F (soundnessConv↑ c) (soundnessConv↑ c₁)
@@ -52,6 +55,7 @@ mutual
   -- Algorithmic equality of terms in WHNF is well-formed.
   soundnessConv↓Term : ∀ {a b A Γ} → Γ ⊢ a [conv↓] b ∷ A → Γ ⊢ a ≡ b ∷ A
   soundnessConv↓Term (ℕ-ins x) = soundness~↓ x
+  soundnessConv↓Term (Empty-ins x) = soundness~↓ x
   soundnessConv↓Term (ne-ins t u x x₁) =
     let _ , neA , _ = ne~↓ x₁
         _ , t∷M , _ = syntacticEqTerm (soundness~↓ x₁)

--- a/Definition/Conversion/Stability.agda
+++ b/Definition/Conversion/Stability.agda
@@ -86,6 +86,8 @@ stabilityRedTerm Γ≡Δ (natrec-suc x x₁ x₂ x₃) =
   let ⊢Γ , _ , _ = contextConvSubst Γ≡Δ
   in  natrec-suc (stabilityTerm Γ≡Δ x) (stability (Γ≡Δ ∙ refl (ℕⱼ ⊢Γ)) x₁)
                  (stabilityTerm Γ≡Δ x₂) (stabilityTerm Γ≡Δ x₃)
+stabilityRedTerm Γ≡Δ (Emptyrec-subst x d) =
+  Emptyrec-subst (stability Γ≡Δ x) (stabilityRedTerm Γ≡Δ d)
 
 -- Stability of type reductions.
 stabilityRed : ∀ {A B Γ Δ} → ⊢ Γ ≡ Δ → Γ ⊢ A ⇒ B → Δ ⊢ A ⇒ B
@@ -117,6 +119,9 @@ mutual
                    (stabilityConv↑Term Γ≡Δ x₂)
                    (stabilityConv↑Term Γ≡Δ x₃)
                    (stability~↓ Γ≡Δ k~l)
+  stability~↑ Γ≡Δ (Emptyrec-cong x₁ k~l) =
+    Emptyrec-cong (stabilityConv↑ Γ≡Δ x₁)
+                (stability~↓ Γ≡Δ k~l)
 
   -- Stability of algorithmic equality of neutrals of types in WHNF.
   stability~↓ : ∀ {k l A Γ Δ}
@@ -146,6 +151,9 @@ mutual
   stabilityConv↓ Γ≡Δ (ℕ-refl x) =
     let _ , ⊢Δ , _ = contextConvSubst Γ≡Δ
     in  ℕ-refl ⊢Δ
+  stabilityConv↓ Γ≡Δ (Empty-refl x) =
+    let _ , ⊢Δ , _ = contextConvSubst Γ≡Δ
+    in  Empty-refl ⊢Δ
   stabilityConv↓ Γ≡Δ (ne x) =
     ne (stability~↓ Γ≡Δ x)
   stabilityConv↓ Γ≡Δ (Π-cong F A<>B A<>B₁) =
@@ -169,6 +177,8 @@ mutual
                      → Δ ⊢ t [conv↓] u ∷ A
   stabilityConv↓Term Γ≡Δ (ℕ-ins x) =
     ℕ-ins (stability~↓ Γ≡Δ x)
+  stabilityConv↓Term Γ≡Δ (Empty-ins x) =
+    Empty-ins (stability~↓ Γ≡Δ x)
   stabilityConv↓Term Γ≡Δ (ne-ins t u neN x) =
     ne-ins (stabilityTerm Γ≡Δ t) (stabilityTerm Γ≡Δ u) neN (stability~↓ Γ≡Δ x)
   stabilityConv↓Term Γ≡Δ (univ x x₁ x₂) =

--- a/Definition/Conversion/Symmetry.agda
+++ b/Definition/Conversion/Symmetry.agda
@@ -49,6 +49,14 @@ mutual
                     (convConvTerm (symConv↑Term Γ≡Δ x₁) F[0]≡G[0])
                     (convConvTerm (symConv↑Term Γ≡Δ x₂) (sucCong F≡G))
                     (PE.subst (λ x → _ ⊢ _ ~ _ ↓ x) B≡ℕ u~t)
+  sym~↑ Γ≡Δ (Emptyrec-cong x t~u) =
+    let ⊢Γ , ⊢Δ , _ = contextConvSubst Γ≡Δ
+        B , whnfB , A≡B , u~t = sym~↓ Γ≡Δ t~u
+        B≡Empty = Empty≡A A≡B whnfB
+        F≡G = stabilityEq Γ≡Δ (soundnessConv↑ x)
+    in  _ , soundnessConv↑ x
+    , Emptyrec-cong (symConv↑ Γ≡Δ x)
+                    (PE.subst (λ x₁ → _ ⊢ _ ~ _ ↓ x₁) B≡Empty u~t)
 
   -- Symmetry of algorithmic equality of neutrals of types in WHNF.
   sym~↓ : ∀ {t u A Γ Δ} → ⊢ Γ ≡ Δ → Γ ⊢ t ~ u ↓ A
@@ -74,6 +82,9 @@ mutual
   symConv↓ Γ≡Δ (ℕ-refl x) =
     let _ , ⊢Δ , _ = contextConvSubst Γ≡Δ
     in  ℕ-refl ⊢Δ
+  symConv↓ Γ≡Δ (Empty-refl x) =
+    let _ , ⊢Δ , _ = contextConvSubst Γ≡Δ
+    in  Empty-refl ⊢Δ
   symConv↓ Γ≡Δ (ne A~B) =
     let B , whnfB , U≡B , B~A = sym~↓ Γ≡Δ A~B
         B≡U = U≡A U≡B
@@ -96,6 +107,10 @@ mutual
     let B , whnfB , A≡B , u~t = sym~↓ Γ≡Δ t~u
         B≡ℕ = ℕ≡A A≡B whnfB
     in  ℕ-ins (PE.subst (λ x → _ ⊢ _ ~ _ ↓ x) B≡ℕ u~t)
+  symConv↓Term Γ≡Δ (Empty-ins t~u) =
+    let B , whnfB , A≡B , u~t = sym~↓ Γ≡Δ t~u
+        B≡Empty = Empty≡A A≡B whnfB
+    in  Empty-ins (PE.subst (λ x → _ ⊢ _ ~ _ ↓ x) B≡Empty u~t)
   symConv↓Term Γ≡Δ (ne-ins t u x t~u) =
     let B , whnfB , A≡B , u~t = sym~↓ Γ≡Δ t~u
     in  ne-ins (stabilityTerm Γ≡Δ u) (stabilityTerm Γ≡Δ t) x u~t

--- a/Definition/Conversion/Transitivity.agda
+++ b/Definition/Conversion/Transitivity.agda
@@ -52,6 +52,12 @@ mutual
         t~v , _ = trans~↓ Γ≡Δ t~u u~v
     in  natrec-cong A<>C a₀<>c₀ aₛ<>cₛ t~v
     ,   substTypeEq A≡B (soundness~↓ t~u)
+  trans~↑ Γ≡Δ (Emptyrec-cong A<>B t~u) (Emptyrec-cong B<>C u~v) =
+    let ⊢Γ , _ , _ = contextConvSubst Γ≡Δ
+        A≡B = soundnessConv↑ A<>B
+        A<>C = transConv↑ Γ≡Δ A<>B B<>C
+        t~v , _ = trans~↓ Γ≡Δ t~u u~v
+    in  Emptyrec-cong A<>C t~v , A≡B
 
   -- Transitivity of algorithmic equality of neutrals with types in WHNF.
   trans~↓ : ∀ {t u v A B Γ Δ}
@@ -90,6 +96,7 @@ mutual
             → Γ ⊢ A [conv↓] C
   transConv↓ Γ≡Δ (U-refl x) (U-refl x₁) = U-refl x
   transConv↓ Γ≡Δ (ℕ-refl x) (ℕ-refl x₁) = ℕ-refl x
+  transConv↓ Γ≡Δ (Empty-refl x) (Empty-refl x₁) = Empty-refl x
   transConv↓ Γ≡Δ (ne x) (ne x₁) =
     let A~C , U≡U = trans~↓ Γ≡Δ x x₁
     in  ne A~C
@@ -98,9 +105,11 @@ mutual
   -- Refutable cases
   transConv↓ Γ≡Δ (U-refl x) (ne ([~] A D whnfB ()))
   transConv↓ Γ≡Δ (ℕ-refl x) (ne ([~] A D whnfB ()))
+  transConv↓ Γ≡Δ (Empty-refl x) (ne ([~] A D whnfB ()))
   transConv↓ Γ≡Δ (Π-cong x x₁ x₂) (ne ([~] A D whnfB ()))
   transConv↓ Γ≡Δ (ne ([~] A₁ D whnfB ())) (U-refl x₁)
   transConv↓ Γ≡Δ (ne ([~] A₁ D whnfB ())) (ℕ-refl x₁)
+  transConv↓ Γ≡Δ (ne ([~] A₁ D whnfB ())) (Empty-refl x₁)
   transConv↓ Γ≡Δ (ne ([~] A₁ D whnfB ())) (Π-cong x₁ x₂ x₃)
 
   -- Transitivity of algorithmic equality of terms.
@@ -133,6 +142,8 @@ mutual
                 → Γ ⊢ t [conv↓] v ∷ A
   transConv↓Term Γ≡Δ A≡B (ℕ-ins x) (ℕ-ins x₁) =
     ℕ-ins (proj₁ (trans~↓ Γ≡Δ x x₁))
+  transConv↓Term Γ≡Δ A≡B (Empty-ins x) (Empty-ins x₁) =
+    Empty-ins (proj₁ (trans~↓ Γ≡Δ x x₁))
   transConv↓Term Γ≡Δ A≡B (ne-ins t u x x₁) (ne-ins t′ u′ x₂ x₃) =
     ne-ins t (conv (stabilityTerm (symConEq Γ≡Δ) u′) (sym A≡B)) x
            (proj₁ (trans~↓ Γ≡Δ x₁ x₃))
@@ -149,28 +160,40 @@ mutual
   -- Refutable cases
   transConv↓Term Γ≡Δ A≡B (ℕ-ins x) (ne-ins t u x₂ x₃) = ⊥-elim (WF.ℕ≢ne x₂ A≡B)
   transConv↓Term Γ≡Δ A≡B (ℕ-ins x) (univ x₂ x₃ x₄) = ⊥-elim (WF.U≢ℕ (sym A≡B))
+  transConv↓Term Γ≡Δ A≡B (ℕ-ins x) (Empty-ins x₁) = ⊥-elim (WF.ℕ≢Emptyⱼ A≡B)
   transConv↓Term Γ≡Δ A≡B (ℕ-ins ([~] A D whnfB ())) (zero-refl x₂)
   transConv↓Term Γ≡Δ A≡B (ℕ-ins ([~] A D whnfB ())) (suc-cong x₂)
   transConv↓Term Γ≡Δ A≡B (ℕ-ins x) (η-eq x₂ x₃ x₄ y y₁ x₅) = ⊥-elim (WF.ℕ≢Π A≡B)
+  transConv↓Term Γ≡Δ A≡B (Empty-ins x) (ne-ins t u x₂ x₃) = ⊥-elim (WF.Empty≢neⱼ x₂ A≡B)
+  transConv↓Term Γ≡Δ A≡B (Empty-ins x) (univ x₂ x₃ x₄) = ⊥-elim (WF.U≢Emptyⱼ (sym A≡B))
+  transConv↓Term Γ≡Δ A≡B (Empty-ins x₁) (ℕ-ins x) = ⊥-elim (WF.ℕ≢Emptyⱼ (sym A≡B))
+  transConv↓Term Γ≡Δ A≡B (Empty-ins ([~] A D whnfB ())) (zero-refl x₂)
+  transConv↓Term Γ≡Δ A≡B (Empty-ins ([~] A D whnfB ())) (suc-cong x₂)
+  transConv↓Term Γ≡Δ A≡B (Empty-ins x) (η-eq x₂ x₃ x₄ y y₁ x₅) = ⊥-elim (WF.Empty≢Πⱼ A≡B)
   transConv↓Term Γ≡Δ A≡B (ne-ins t u x x₁) (ℕ-ins x₂) = ⊥-elim (WF.ℕ≢ne x (sym A≡B))
+  transConv↓Term Γ≡Δ A≡B (ne-ins t u x x₁) (Empty-ins x₂) = ⊥-elim (WF.Empty≢neⱼ x (sym A≡B))
   transConv↓Term Γ≡Δ A≡B (ne-ins t u x x₁) (univ x₃ x₄ x₅) = ⊥-elim (WF.U≢ne x (sym A≡B))
   transConv↓Term Γ≡Δ A≡B (ne-ins t u x ([~] A D whnfB ())) (zero-refl x₃)
   transConv↓Term Γ≡Δ A≡B (ne-ins t u x ([~] A D whnfB ())) (suc-cong x₃)
   transConv↓Term Γ≡Δ A≡B (ne-ins t u x x₁) (η-eq x₃ x₄ x₅ y y₁ x₆) = ⊥-elim (WF.Π≢ne x (sym A≡B))
   transConv↓Term Γ≡Δ A≡B (univ x x₁ x₂) (ℕ-ins x₃) = ⊥-elim (WF.U≢ℕ A≡B)
+  transConv↓Term Γ≡Δ A≡B (univ x x₁ x₂) (Empty-ins x₃) = ⊥-elim (WF.U≢Emptyⱼ A≡B)
   transConv↓Term Γ≡Δ A≡B (univ x x₁ x₂) (ne-ins t u x₃ x₄) = ⊥-elim (WF.U≢ne x₃ A≡B)
   transConv↓Term Γ≡Δ A≡B (univ x x₁ x₂) (zero-refl x₃) = ⊥-elim (WF.U≢ℕ A≡B)
   transConv↓Term Γ≡Δ A≡B (univ x x₁ x₂) (suc-cong x₃) = ⊥-elim (WF.U≢ℕ A≡B)
   transConv↓Term Γ≡Δ A≡B (univ x x₁ x₂) (η-eq x₃ x₄ x₅ y y₁ x₆) = ⊥-elim (WF.U≢Π A≡B)
   transConv↓Term Γ≡Δ A≡B (zero-refl x) (ℕ-ins ([~] A D whnfB ()))
+  transConv↓Term Γ≡Δ A≡B (zero-refl x) (Empty-ins ([~] A D whnfB ()))
   transConv↓Term Γ≡Δ A≡B (zero-refl x) (ne-ins t u x₁ ([~] A D whnfB ()))
   transConv↓Term Γ≡Δ A≡B (zero-refl x) (univ x₁ x₂ x₃) = ⊥-elim (WF.U≢ℕ (sym A≡B))
   transConv↓Term Γ≡Δ A≡B (zero-refl x) (η-eq x₁ x₂ x₃ y y₁ x₄) = ⊥-elim (WF.ℕ≢Π A≡B)
   transConv↓Term Γ≡Δ A≡B (suc-cong x) (ℕ-ins ([~] A D whnfB ()))
+  transConv↓Term Γ≡Δ A≡B (suc-cong x) (Empty-ins ([~] A D whnfB ()))
   transConv↓Term Γ≡Δ A≡B (suc-cong x) (ne-ins t u x₁ ([~] A D whnfB ()))
   transConv↓Term Γ≡Δ A≡B (suc-cong x) (univ x₁ x₂ x₃) = ⊥-elim (WF.U≢ℕ (sym A≡B))
   transConv↓Term Γ≡Δ A≡B (suc-cong x) (η-eq x₁ x₂ x₃ y y₁ x₄) = ⊥-elim (WF.ℕ≢Π A≡B)
   transConv↓Term Γ≡Δ A≡B (η-eq x x₁ x₂ y y₁ x₃) (ℕ-ins x₄) = ⊥-elim (WF.ℕ≢Π (sym A≡B))
+  transConv↓Term Γ≡Δ A≡B (η-eq x x₁ x₂ y y₁ x₃) (Empty-ins x₄) = ⊥-elim (WF.Empty≢Πⱼ (sym A≡B))
   transConv↓Term Γ≡Δ A≡B (η-eq x x₁ x₂ y y₁ x₃) (ne-ins t u x₄ x₅) = ⊥-elim (WF.Π≢ne x₄ A≡B)
   transConv↓Term Γ≡Δ A≡B (η-eq x x₁ x₂ y y₁ x₃) (univ x₄ x₅ x₆) = ⊥-elim (WF.U≢Π (sym A≡B))
   transConv↓Term Γ≡Δ A≡B (η-eq x x₁ x₂ y y₁ x₃) (zero-refl x₄) = ⊥-elim (WF.ℕ≢Π (sym A≡B))

--- a/Definition/Conversion/Weakening.agda
+++ b/Definition/Conversion/Weakening.agda
@@ -27,6 +27,8 @@ mutual
                           (PE.subst (λ x → Δ ⊢ U.wk ρ h [conv↑] U.wk ρ g ∷ x)
                                     (wk-β-natrec _ F) (wkConv↑Term [ρ] ⊢Δ x₂))
                           (wk~↓ [ρ] ⊢Δ t~u))
+  wk~↑ {ρ} {Δ = Δ} [ρ] ⊢Δ (Emptyrec-cong {k} {l} {F} {G} x t~u) =
+    Emptyrec-cong (wkConv↑ [ρ] ⊢Δ x) (wk~↓ [ρ] ⊢Δ t~u)
 
   -- Weakening of algorithmic equality of neutrals in WHNF.
   wk~↓ : ∀ {ρ t u A Γ Δ} ([ρ] : ρ ∷ Δ ⊆ Γ) → ⊢ Δ
@@ -49,6 +51,7 @@ mutual
          → Δ ⊢ U.wk ρ A [conv↓] U.wk ρ B
   wkConv↓ ρ ⊢Δ (U-refl x) = U-refl ⊢Δ
   wkConv↓ ρ ⊢Δ (ℕ-refl x) = ℕ-refl ⊢Δ
+  wkConv↓ ρ ⊢Δ (Empty-refl x) = Empty-refl ⊢Δ
   wkConv↓ ρ ⊢Δ (ne x) = ne (wk~↓ ρ ⊢Δ x)
   wkConv↓ ρ ⊢Δ (Π-cong x A<>B A<>B₁) =
     let ⊢ρF = wk ρ ⊢Δ x
@@ -70,6 +73,8 @@ mutual
              → Δ ⊢ U.wk ρ t [conv↓] U.wk ρ u ∷ U.wk ρ A
   wkConv↓Term ρ ⊢Δ (ℕ-ins x) =
     ℕ-ins (wk~↓ ρ ⊢Δ x)
+  wkConv↓Term ρ ⊢Δ (Empty-ins x) =
+    Empty-ins (wk~↓ ρ ⊢Δ x)
   wkConv↓Term {ρ} [ρ] ⊢Δ (ne-ins t u x x₁) =
     ne-ins (wkTerm [ρ] ⊢Δ t) (wkTerm [ρ] ⊢Δ u) (wkNeutral ρ x) (wk~↓ [ρ] ⊢Δ x₁)
   wkConv↓Term ρ ⊢Δ (univ x x₁ x₂) =

--- a/Definition/Conversion/Whnf.agda
+++ b/Definition/Conversion/Whnf.agda
@@ -19,6 +19,8 @@ mutual
                          in  ∘ₙ q , ∘ₙ w
   ne~↑ (natrec-cong x x₁ x₂ x₃) = let _ , q , w = ne~↓ x₃
                                   in  natrecₙ q , natrecₙ w
+  ne~↑ (Emptyrec-cong x x₁) = let _ , q , w = ne~↓ x₁
+                              in Emptyrecₙ q , Emptyrecₙ w
 
   -- Extraction of neutrality and WHNF from algorithmic equality of neutrals
   -- with type in WHNF.
@@ -33,6 +35,7 @@ whnfConv↓ : ∀ {A B Γ}
           → Whnf A × Whnf B
 whnfConv↓ (U-refl x) = Uₙ , Uₙ
 whnfConv↓ (ℕ-refl x) = ℕₙ , ℕₙ
+whnfConv↓ (Empty-refl x) = Emptyₙ , Emptyₙ
 whnfConv↓ (ne x) = let _ , neA , neB = ne~↓ x
                    in  ne neA , ne neB
 whnfConv↓ (Π-cong x x₁ x₂) = Πₙ , Πₙ
@@ -43,6 +46,8 @@ whnfConv↓Term : ∀ {t u A Γ}
               → Whnf A × Whnf t × Whnf u
 whnfConv↓Term (ℕ-ins x) = let _ , neT , neU = ne~↓ x
                           in ℕₙ , ne neT , ne neU
+whnfConv↓Term (Empty-ins x) = let _ , neT , neU = ne~↓ x
+                          in Emptyₙ , ne neT , ne neU
 whnfConv↓Term (ne-ins t u x x₁) =
   let _ , neT , neU = ne~↓ x₁
   in ne x , ne neT , ne neU

--- a/Definition/LogicalRelation/Fundamental.agda
+++ b/Definition/LogicalRelation/Fundamental.agda
@@ -35,6 +35,7 @@ mutual
   -- Fundamental theorem for types.
   fundamental : ∀ {Γ A} (⊢A : Γ ⊢ A) → Σ (⊩ᵛ Γ) (λ [Γ] → Γ ⊩ᵛ⟨ ¹ ⟩ A / [Γ])
   fundamental (ℕⱼ x) = valid x , ℕᵛ (valid x)
+  fundamental (Emptyⱼ x) = valid x , Emptyᵛ (valid x)
   fundamental (Uⱼ x) = valid x , Uᵛ (valid x)
   fundamental (Πⱼ_▹_ {F} {G} ⊢F ⊢G) with fundamental ⊢F | fundamental ⊢G
   fundamental (Πⱼ_▹_ {F} {G} ⊢F ⊢G) | [Γ] , [F] | [Γ∙F] , [G] =
@@ -138,6 +139,7 @@ mutual
     → ∃ λ ([A] : Γ ⊩ᵛ⟨ ¹ ⟩ A / [Γ])
     → Γ ⊩ᵛ⟨ ¹ ⟩ t ∷ A / [Γ] / [A]
   fundamentalTerm (ℕⱼ x) = valid x , Uᵛ (valid x) , ℕᵗᵛ (valid x)
+  fundamentalTerm (Emptyⱼ x) = valid x , Uᵛ (valid x) , Emptyᵗᵛ (valid x)
   fundamentalTerm (Πⱼ_▹_ {F} {G} ⊢F ⊢G)
     with fundamentalTerm ⊢F | fundamentalTerm ⊢G
   ... | [Γ] , [U] , [F]ₜ | [Γ]₁ , [U]₁ , [G]ₜ =
@@ -185,6 +187,11 @@ mutual
         [s]′ = S.irrelevanceTerm {A = sType} {t = s} [Γ]₂ [Γ]′ [G₊] [G₊]′ [s]
     in  [Γ]′ , [Gₙ]′
     ,   natrecᵛ {G} {z} {s} {n} [Γ]′ [ℕ] [G]′ [G₀]′ [G₊]′ [Gₙ]′ [z]′ [s]′ [n]
+  fundamentalTerm (Emptyrecⱼ {A} {n} ⊢A ⊢n)
+    with fundamental ⊢A | fundamentalTerm ⊢n
+  ... | [Γ] , [A] | [Γ]′ , [Empty] , [n] =
+    let [A]′ = S.irrelevance {A = A} [Γ] [Γ]′ [A]
+    in [Γ]′ , [A]′ , Emptyrecᵛ {A} {n} [Γ]′ [Empty] [A]′ [n]
   fundamentalTerm (conv {t} {A} {B} ⊢t A′≡A)
     with fundamentalTerm ⊢t | fundamentalEq A′≡A
   fundamentalTerm (conv {t} {A} {B} ⊢t A′≡A) | [Γ] , [A′] , [t]
@@ -512,6 +519,24 @@ mutual
                            r)
                         [F[sucn]] y
     in  [Γ]₃ , modelsTermEq [F[sucn]] d y r
+  fundamentalTermEq (Emptyrec-cong {F} {F′} {n} {n′}
+                                 F≡F′ n≡n′)
+    with fundamentalEq F≡F′ |
+         fundamentalTermEq n≡n′
+  fundamentalTermEq (Emptyrec-cong {F} {F′} {n} {n′}
+                                 F≡F′ n≡n′) |
+    [Γ]  , [F] , [F′] , [F≡F′] |
+    [Γ]′ , modelsTermEq [Empty] [n] [n′] [n≡n′] =
+    let [F]′ = S.irrelevance {A = F} [Γ] [Γ]′ [F]
+        [F′]′ = S.irrelevance {A = F′} [Γ] [Γ]′ [F′]
+        [F≡F′]′ = S.irrelevanceEq {A = F} {B = F′} [Γ] [Γ]′ [F] [F]′ [F≡F′]
+    in [Γ]′
+      , modelsTermEq [F]′ (Emptyrecᵛ {F} {n} [Γ]′ [Empty] [F]′ [n])
+                     (conv₂ᵛ {Emptyrec F′ n′} {F} {F′} [Γ]′ [F]′ [F′]′ [F≡F′]′
+                       (Emptyrecᵛ {F′} {n′} [Γ]′ [Empty] [F′]′ [n′]))
+                     (Emptyrec-congᵛ {F} {F′} {n} {n′}
+                       [Γ]′ [Empty] [F]′ [F′]′ [F≡F′]′
+                       [n] [n′] [n≡n′])
 
 -- Fundamental theorem for substitutions.
 fundamentalSubst : ∀ {Γ Δ σ} (⊢Γ : ⊢ Γ) (⊢Δ : ⊢ Δ)

--- a/Definition/LogicalRelation/Irrelevance.agda
+++ b/Definition/LogicalRelation/Irrelevance.agda
@@ -66,6 +66,7 @@ mutual
                        → ShapeView Γ l l′ A A p q
                        → Γ ⊩⟨ l ⟩ A ≡ B / p → Γ ⊩⟨ l′ ⟩ A ≡ B / q
   irrelevanceEqT (ℕᵥ D D′) A≡B = A≡B
+  irrelevanceEqT (Emptyᵥ D D′) A≡B = A≡B
   irrelevanceEqT (ne (ne K D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (ne₌ M D′ neM K≡M)
                  rewrite whrDet* (red D , ne neK) (red D₁ , ne neK₁) =
     ne₌ M D′ neM K≡M
@@ -122,6 +123,7 @@ mutual
                          → ShapeView Γ l l′ A A p q
                          → Γ ⊩⟨ l ⟩ t ∷ A / p → Γ ⊩⟨ l′ ⟩ t ∷ A / q
   irrelevanceTermT (ℕᵥ D D′) t = t
+  irrelevanceTermT (Emptyᵥ D D′) t = t
   irrelevanceTermT (ne (ne K D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (neₜ k d nf)
                    with whrDet* (red D₁ , ne neK₁) (red D , ne neK)
   irrelevanceTermT (ne (ne K D neK K≡K) (ne .K D₁ neK₁ K≡K₁)) (neₜ k d nf)
@@ -177,6 +179,7 @@ mutual
                            → ShapeView Γ l l′ A A p q
                            → Γ ⊩⟨ l ⟩ t ≡ u ∷ A / p → Γ ⊩⟨ l′ ⟩ t ≡ u ∷ A / q
   irrelevanceEqTermT (ℕᵥ D D′) t≡u = t≡u
+  irrelevanceEqTermT (Emptyᵥ D D′) t≡u = t≡u
   irrelevanceEqTermT (ne (ne K D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (neₜ₌ k m d d′ nf)
                      with whrDet* (red D₁ , ne neK₁) (red D , ne neK)
   irrelevanceEqTermT (ne (ne K D neK K≡K) (ne .K D₁ neK₁ K≡K₁)) (neₜ₌ k m d d′ nf)

--- a/Definition/LogicalRelation/Properties/Conversion.agda
+++ b/Definition/LogicalRelation/Properties/Conversion.agda
@@ -29,6 +29,7 @@ mutual
              → Γ ⊩⟨ l ⟩  t ∷ A / [A]
              → Γ ⊩⟨ l′ ⟩ t ∷ B / [B]
   convTermT₁ (ℕᵥ D D′) A≡B t = t
+  convTermT₁ (Emptyᵥ D D′) A≡B t = t
   convTermT₁ (ne (ne K D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (ne₌ M D′ neM K≡M)
              (neₜ k d (neNfₜ neK₂ ⊢k k≡k)) =
     let K≡K₁ = PE.subst (λ x → _ ⊢ _ ≡ x)
@@ -77,6 +78,7 @@ mutual
            → Γ ⊩⟨ l′ ⟩ t ∷ B / [B]
            → Γ ⊩⟨ l ⟩  t ∷ A / [A]
   convTermT₂ (ℕᵥ D D′) A≡B t = t
+  convTermT₂ (Emptyᵥ D D′) A≡B t = t
   convTermT₂ (ne (ne K D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (ne₌ M D′ neM K≡M)
              (neₜ k d (neNfₜ neK₂ ⊢k k≡k)) =
     let K₁≡K = PE.subst (λ x → _ ⊢ x ≡ _)
@@ -150,6 +152,7 @@ mutual
                → Γ ⊩⟨ l ⟩  t ≡ u ∷ A / [A]
                → Γ ⊩⟨ l′ ⟩ t ≡ u ∷ B / [B]
   convEqTermT₁ (ℕᵥ D D′) A≡B t≡u = t≡u
+  convEqTermT₁ (Emptyᵥ D D′) A≡B t≡u = t≡u
   convEqTermT₁ (ne (ne K D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (ne₌ M D′ neM K≡M)
                (neₜ₌ k m d d′ (neNfₜ₌ neK₂ neM₁ k≡m)) =
     let K≡K₁ = PE.subst (λ x → _ ⊢ _ ≡ x)
@@ -193,6 +196,7 @@ mutual
              → Γ ⊩⟨ l′ ⟩ t ≡ u ∷ B / [B]
              → Γ ⊩⟨ l ⟩  t ≡ u ∷ A / [A]
   convEqTermT₂ (ℕᵥ D D′) A≡B t≡u = t≡u
+  convEqTermT₂ (Emptyᵥ D D′) A≡B t≡u = t≡u
   convEqTermT₂ (ne (ne K D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (ne₌ M D′ neM K≡M)
                (neₜ₌ k m d d′ (neNfₜ₌ neK₂ neM₁ k≡m)) =
     let K₁≡K = PE.subst (λ x → _ ⊢ x ≡ _)

--- a/Definition/LogicalRelation/Properties/Escape.agda
+++ b/Definition/LogicalRelation/Properties/Escape.agda
@@ -19,6 +19,7 @@ import Tools.PropositionalEquality as PE
 escape : ∀ {l Γ A} → Γ ⊩⟨ l ⟩ A → Γ ⊢ A
 escape (Uᵣ′ l′ l< ⊢Γ) = Uⱼ ⊢Γ
 escape (ℕᵣ [ ⊢A , ⊢B , D ]) = ⊢A
+escape (Emptyᵣ [ ⊢A , ⊢B , D ]) = ⊢A
 escape (ne′ K [ ⊢A , ⊢B , D ] neK K≡K) = ⊢A
 escape (Πᵣ′ F G [ ⊢A , ⊢B , D ] ⊢F ⊢G A≡A [F] [G] G-ext) = ⊢A
 escape (emb 0<1 A) = escape A
@@ -29,6 +30,7 @@ escapeEq : ∀ {l Γ A B} → ([A] : Γ ⊩⟨ l ⟩ A)
             → Γ ⊢ A ≅ B
 escapeEq (Uᵣ′ l′ l< ⊢Γ) PE.refl = ≅-Urefl ⊢Γ
 escapeEq (ℕᵣ [ ⊢A , ⊢B , D ]) D′ = ≅-red D D′ ℕₙ ℕₙ (≅-ℕrefl (wf ⊢A))
+escapeEq (Emptyᵣ [ ⊢A , ⊢B , D ]) D′ = ≅-red D D′ Emptyₙ Emptyₙ (≅-Emptyrefl (wf ⊢A))
 escapeEq (ne′ K D neK K≡K) (ne₌ M D′ neM K≡M) =
   ≅-red (red D) (red D′) (ne neK) (ne neM) (~-to-≅ K≡M)
 escapeEq (Πᵣ′ F G D ⊢F ⊢G A≡A [F] [G] G-ext)
@@ -42,6 +44,8 @@ escapeTerm : ∀ {l Γ A t} → ([A] : Γ ⊩⟨ l ⟩ A)
               → Γ ⊢ t ∷ A
 escapeTerm (Uᵣ′ l′ l< ⊢Γ) (Uₜ A [ ⊢t , ⊢u , d ] typeA A≡A [A]) = ⊢t
 escapeTerm (ℕᵣ D) (ℕₜ n [ ⊢t , ⊢u , d ] t≡t prop) =
+  conv ⊢t (sym (subset* (red D)))
+escapeTerm (Emptyᵣ D) (Emptyₜ e [ ⊢t , ⊢u , d ] t≡t prop) =
   conv ⊢t (sym (subset* (red D)))
 escapeTerm (ne′ K D neK K≡K) (neₜ k [ ⊢t , ⊢u , d ] nf) =
   conv ⊢t (sym (subset* (red D)))
@@ -60,6 +64,10 @@ escapeTermEq (ℕᵣ D) (ℕₜ₌ k k′ d d′ k≡k′ prop) =
   let natK , natK′ = split prop
   in  ≅ₜ-red (red D) (redₜ d) (redₜ d′) ℕₙ
              (naturalWhnf natK) (naturalWhnf natK′) k≡k′
+escapeTermEq (Emptyᵣ D) (Emptyₜ₌ k k′ d d′ k≡k′ prop) =
+  let natK , natK′ = esplit prop
+  in  ≅ₜ-red (red D) (redₜ d) (redₜ d′) Emptyₙ
+             (ne natK) (ne natK′) k≡k′
 escapeTermEq (ne′ K D neK K≡K)
                  (neₜ₌ k m d d′ (neNfₜ₌ neT neU t≡u)) =
   ≅ₜ-red (red D) (redₜ d) (redₜ d′) (ne neK) (ne neT) (ne neU)

--- a/Definition/LogicalRelation/Properties/Neutral.agda
+++ b/Definition/LogicalRelation/Properties/Neutral.agda
@@ -64,6 +64,11 @@ mutual
         n~n′ = ~-conv n~n A≡ℕ
         n≡n  = ~-to-≅ₜ n~n′
     in  ℕₜ _ (idRedTerm:*: (conv n A≡ℕ)) n≡n (ne (neNfₜ neN (conv n A≡ℕ) n~n′))
+  neuTerm (Emptyᵣ [ ⊢A , ⊢B , D ]) neN n n~n =
+    let A≡Empty  = subset* D
+        n~n′ = ~-conv n~n A≡Empty
+        n≡n  = ~-to-≅ₜ n~n′
+    in  Emptyₜ _ (idRedTerm:*: (conv n A≡Empty)) n≡n (ne (neNfₜ neN (conv n A≡Empty) n~n′))
   neuTerm (ne′ K [ ⊢A , ⊢B , D ] neK K≡K) neN n n~n =
     let A≡K = subset* D
     in  neₜ _ (idRedTerm:*: (conv n A≡K)) (neNfₜ neN (conv n A≡K)
@@ -113,6 +118,12 @@ mutual
         n~n′₁ = ~-conv n~n′ A≡ℕ
         n≡n′ = ~-to-≅ₜ n~n′₁
     in  ℕₜ₌ _ _ (idRedTerm:*: (conv n A≡ℕ)) (idRedTerm:*: (conv n′ A≡ℕ))
+            n≡n′ (ne (neNfₜ₌ neN neN′ n~n′₁))
+  neuEqTerm (Emptyᵣ [ ⊢A , ⊢B , D ]) neN neN′ n n′ n~n′ =
+    let A≡Empty = subset* D
+        n~n′₁ = ~-conv n~n′ A≡Empty
+        n≡n′ = ~-to-≅ₜ n~n′₁
+    in  Emptyₜ₌ _ _ (idRedTerm:*: (conv n A≡Empty)) (idRedTerm:*: (conv n′ A≡Empty))
             n≡n′ (ne (neNfₜ₌ neN neN′ n~n′₁))
   neuEqTerm (ne (ne K [ ⊢A , ⊢B , D ] neK K≡K)) neN neN′ n n′ n~n′ =
     let A≡K = subset* D

--- a/Definition/LogicalRelation/Properties/Reduction.agda
+++ b/Definition/LogicalRelation/Properties/Reduction.agda
@@ -28,6 +28,9 @@ redSubst* D (Uᵣ′ l′ l< ⊢Γ) rewrite redU* D =
 redSubst* D (ℕᵣ [ ⊢B , ⊢ℕ , D′ ]) =
   let ⊢A = redFirst* D
   in  ℕᵣ ([ ⊢A , ⊢ℕ , D ⇨* D′ ]) , D′
+redSubst* D (Emptyᵣ [ ⊢B , ⊢Empty , D′ ]) =
+  let ⊢A = redFirst* D
+  in  Emptyᵣ ([ ⊢A , ⊢Empty , D ⇨* D′ ]) , D′
 redSubst* D (ne′ K [ ⊢B , ⊢K , D′ ] neK K≡K) =
   let ⊢A = redFirst* D
   in  (ne′ K [ ⊢A , ⊢K , D ⇨* D′ ] neK K≡K)
@@ -60,6 +63,13 @@ redSubst*Term t⇒u (ℕᵣ D) (ℕₜ n [ ⊢u , ⊢n , d ] n≡n prop) =
   in  ℕₜ n [ ⊢t , ⊢n , t⇒u′ ⇨∷* d ] n≡n prop
   ,   ℕₜ₌ n n [ ⊢t , ⊢n , t⇒u′ ⇨∷* d ] [ ⊢u , ⊢n , d ]
           n≡n (reflNatural-prop prop)
+redSubst*Term t⇒u (Emptyᵣ D) (Emptyₜ n [ ⊢u , ⊢n , d ] n≡n prop) =
+  let A≡Empty  = subset* (red D)
+      ⊢t   = conv (redFirst*Term t⇒u) A≡Empty
+      t⇒u′ = conv* t⇒u A≡Empty
+  in  Emptyₜ n [ ⊢t , ⊢n , t⇒u′ ⇨∷* d ] n≡n prop
+  ,   Emptyₜ₌ n n [ ⊢t , ⊢n , t⇒u′ ⇨∷* d ] [ ⊢u , ⊢n , d ]
+          n≡n (reflEmpty-prop prop)
 redSubst*Term t⇒u (ne′ K D neK K≡K) (neₜ k [ ⊢t , ⊢u , d ] (neNfₜ neK₁ ⊢k k≡k)) =
   let A≡K  = subset* (red D)
       [d]  = [ ⊢t , ⊢u , d ]

--- a/Definition/LogicalRelation/Properties/Reflexivity.agda
+++ b/Definition/LogicalRelation/Properties/Reflexivity.agda
@@ -16,6 +16,7 @@ import Tools.PropositionalEquality as PE
 reflEq : ∀ {l Γ A} ([A] : Γ ⊩⟨ l ⟩ A) → Γ ⊩⟨ l ⟩ A ≡ A / [A]
 reflEq (Uᵣ′ l′ l< ⊢Γ) = PE.refl
 reflEq (ℕᵣ D) = red D
+reflEq (Emptyᵣ D) = red D
 reflEq (ne′ K [ ⊢A , ⊢B , D ] neK K≡K) =
   ne₌ _ [ ⊢A , ⊢B , D ] neK K≡K
 reflEq (Πᵣ′ F G [ ⊢A , ⊢B , D ] ⊢F ⊢G A≡A [F] [G] G-ext) =
@@ -33,6 +34,11 @@ reflNatural-prop (sucᵣ (ℕₜ n d t≡t prop)) =
 reflNatural-prop zeroᵣ = zeroᵣ
 reflNatural-prop (ne (neNfₜ neK ⊢k k≡k)) = ne (neNfₜ₌ neK neK k≡k)
 
+reflEmpty-prop : ∀ {Γ n}
+                 → Empty-prop Γ n
+                 → [Empty]-prop Γ n n
+reflEmpty-prop (ne (neNfₜ neK ⊢k k≡k)) = ne (neNfₜ₌ neK neK k≡k)
+
 -- Reflexivity of reducible terms.
 reflEqTerm : ∀ {l Γ A t} ([A] : Γ ⊩⟨ l ⟩ A)
            → Γ ⊩⟨ l ⟩ t ∷ A / [A]
@@ -42,6 +48,9 @@ reflEqTerm (Uᵣ′ ⁰ 0<1 ⊢Γ) (Uₜ A d typeA A≡A [A]) =
 reflEqTerm (ℕᵣ D) (ℕₜ n [ ⊢t , ⊢u , d ] t≡t prop) =
   ℕₜ₌ n n [ ⊢t , ⊢u , d ] [ ⊢t , ⊢u , d ] t≡t
       (reflNatural-prop prop)
+reflEqTerm (Emptyᵣ D) (Emptyₜ n [ ⊢t , ⊢u , d ] t≡t prop) =
+  Emptyₜ₌ n n [ ⊢t , ⊢u , d ] [ ⊢t , ⊢u , d ] t≡t
+    (reflEmpty-prop prop)
 reflEqTerm (ne′ K D neK K≡K) (neₜ k d (neNfₜ neK₁ ⊢k k≡k)) =
   neₜ₌ k k d d (neNfₜ₌ neK₁ neK₁ k≡k)
 reflEqTerm (Πᵣ′ F G D ⊢F ⊢G A≡A [F] [G] G-ext) (Πₜ f d funcF f≡f [f] [f]₁) =

--- a/Definition/LogicalRelation/Properties/Symmetry.agda
+++ b/Definition/LogicalRelation/Properties/Symmetry.agda
@@ -24,6 +24,7 @@ mutual
          → Γ ⊩⟨ l  ⟩ A ≡ B / [A]
          → Γ ⊩⟨ l′ ⟩ B ≡ A / [B]
   symEqT (ℕᵥ D D′) A≡B = red D
+  symEqT (Emptyᵥ D D′) A≡B = red D
   symEqT (ne (ne K D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (ne₌ M D′ neM K≡M)
          rewrite whrDet* (red D′ , ne neM) (red D₁ , ne neK₁) =
     ne₌ _ D neK
@@ -76,6 +77,11 @@ symNatural-prop (sucᵣ (ℕₜ₌ k k′ d d′ t≡u prop)) =
 symNatural-prop zeroᵣ = zeroᵣ
 symNatural-prop (ne prop) = ne (symNeutralTerm prop)
 
+symEmpty-prop : ∀ {Γ k k′}
+                → [Empty]-prop Γ k k′
+                → [Empty]-prop Γ k′ k
+symEmpty-prop (ne prop) = ne (symNeutralTerm prop)
+
 -- Symmetry of term equality.
 symEqTerm : ∀ {l Γ A t u} ([A] : Γ ⊩⟨ l ⟩ A)
           → Γ ⊩⟨ l ⟩ t ≡ u ∷ A / [A]
@@ -84,6 +90,8 @@ symEqTerm (Uᵣ′ .⁰ 0<1 ⊢Γ) (Uₜ₌ A B d d′ typeA typeB A≡B [A] [B]
   Uₜ₌ B A d′ d typeB typeA (≅ₜ-sym A≡B) [B] [A] (symEq [A] [B] [A≡B])
 symEqTerm (ℕᵣ D) (ℕₜ₌ k k′ d d′ t≡u prop) =
   ℕₜ₌ k′ k d′ d (≅ₜ-sym t≡u) (symNatural-prop prop)
+symEqTerm (Emptyᵣ D) (Emptyₜ₌ k k′ d d′ t≡u prop) =
+  Emptyₜ₌ k′ k d′ d (≅ₜ-sym t≡u) (symEmpty-prop prop)
 symEqTerm (ne′ K D neK K≡K) (neₜ₌ k m d d′ nf) =
   neₜ₌ m k d′ d (symNeutralTerm nf)
 symEqTerm (Πᵣ′ F G D ⊢F ⊢G A≡A [F] [G] G-ext)

--- a/Definition/LogicalRelation/Properties/Transitivity.agda
+++ b/Definition/LogicalRelation/Properties/Transitivity.agda
@@ -26,6 +26,7 @@ mutual
            → Γ ⊩⟨ l′ ⟩ B ≡ C / [B]
            → Γ ⊩⟨ l ⟩  A ≡ C / [A]
   transEqT (ℕᵥ D D′ D″) A≡B B≡C = B≡C
+  transEqT (Emptyᵥ D D′ D″) A≡B B≡C = B≡C
   transEqT (ne (ne K [ ⊢A , ⊢B , D ] neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)
                (ne K₂ D₂ neK₂ K≡K₂))
            (ne₌ M D′ neM K≡M) (ne₌ M₁ D″ neM₁ K≡M₁)
@@ -138,6 +139,28 @@ mutual
   transNatural-prop (ne [k≡k′]) (ne [k′≡k″]) =
     ne (transEqTermNe [k≡k′] [k′≡k″])
 
+-- Empty
+transEmpty-prop : ∀ {Γ k k′ k″}
+  → [Empty]-prop Γ k k′
+  → [Empty]-prop Γ k′ k″
+  → [Empty]-prop Γ k k″
+transEmpty-prop (ne [k≡k′]) (ne [k′≡k″]) =
+  ne (transEqTermNe [k≡k′] [k′≡k″])
+
+transEqTermEmpty : ∀ {Γ n n′ n″}
+  → Γ ⊩Empty n  ≡ n′  ∷Empty
+  → Γ ⊩Empty n′ ≡ n″ ∷Empty
+  → Γ ⊩Empty n  ≡ n″ ∷Empty
+transEqTermEmpty (Emptyₜ₌ k k′ d d′ t≡u prop)
+             (Emptyₜ₌ k₁ k″ d₁ d″ t≡u₁ prop₁) =
+  let k₁Whnf = ne (proj₁ (esplit prop₁))
+      k′Whnf = ne (proj₂ (esplit prop))
+      k₁≡k′ = whrDet*Term (redₜ d₁ , k₁Whnf) (redₜ d′ , k′Whnf)
+      prop′ = PE.subst (λ x → [Empty]-prop _ x _) k₁≡k′ prop₁
+    in  Emptyₜ₌ k k″ d d″ (≅ₜ-trans t≡u (PE.subst (λ x → _ ⊢ x ≅ _ ∷ _) k₁≡k′ t≡u₁))
+      (transEmpty-prop prop prop′)
+
+
 -- Transitivty of term equality.
 transEqTerm : ∀ {l Γ A t u v}
               ([A] : Γ ⊩⟨ l ⟩ A)
@@ -151,6 +174,7 @@ transEqTerm (Uᵣ′ .⁰ 0<1 ⊢Γ)
   Uₜ₌ A B₁ d d₁′ typeA typeB₁ (≅ₜ-trans t≡u t≡u₁) [t] [u]₁
       (transEq [t] [u] [u]₁ [t≡u] (irrelevanceEq [t]₁ [u] [t≡u]₁))
 transEqTerm (ℕᵣ D) [t≡u] [u≡v] = transEqTermℕ [t≡u] [u≡v]
+transEqTerm (Emptyᵣ D) [t≡u] [u≡v] = transEqTermEmpty [t≡u] [u≡v]
 transEqTerm (ne′ K D neK K≡K) (neₜ₌ k m d d′ (neNfₜ₌ neK₁ neM k≡m))
                               (neₜ₌ k₁ m₁ d₁ d″ (neNfₜ₌ neK₂ neM₁ k≡m₁)) =
   let k₁≡m = whrDet*Term (redₜ d₁ , ne neK₂) (redₜ d′ , ne neM)

--- a/Definition/LogicalRelation/ShapeView.agda
+++ b/Definition/LogicalRelation/ShapeView.agda
@@ -29,6 +29,9 @@ _⊩⟨_⟩U : (Γ : Con Term) (l : TypeLevel) → Set
 _⊩⟨_⟩ℕ_ : (Γ : Con Term) (l : TypeLevel) (A : Term) → Set
 Γ ⊩⟨ l ⟩ℕ A = MaybeEmb l (λ l′ → Γ ⊩ℕ A)
 
+_⊩⟨_⟩Empty_ : (Γ : Con Term) (l : TypeLevel) (A : Term) → Set
+Γ ⊩⟨ l ⟩Empty A = MaybeEmb l (λ l′ → Γ ⊩Empty A)
+
 _⊩⟨_⟩ne_ : (Γ : Con Term) (l : TypeLevel) (A : Term) → Set
 Γ ⊩⟨ l ⟩ne A = MaybeEmb l (λ l′ → Γ ⊩ne A)
 
@@ -45,6 +48,10 @@ U-intr (emb 0<1 x) = emb 0<1 (U-intr x)
 ℕ-intr (noemb x) = ℕᵣ x
 ℕ-intr (emb 0<1 x) = emb 0<1 (ℕ-intr x)
 
+Empty-intr : ∀ {A Γ l} → Γ ⊩⟨ l ⟩Empty A → Γ ⊩⟨ l ⟩ A
+Empty-intr (noemb x) = Emptyᵣ x
+Empty-intr (emb 0<1 x) = emb 0<1 (Empty-intr x)
+
 ne-intr : ∀ {A Γ l} → Γ ⊩⟨ l ⟩ne A → Γ ⊩⟨ l ⟩ A
 ne-intr (noemb x) = ne x
 ne-intr (emb 0<1 x) = emb 0<1 (ne-intr x)
@@ -58,6 +65,7 @@ ne-intr (emb 0<1 x) = emb 0<1 (ne-intr x)
 U-elim : ∀ {Γ l} → Γ ⊩⟨ l ⟩ U → Γ ⊩⟨ l ⟩U
 U-elim (Uᵣ′ l′ l< ⊢Γ) = noemb (Uᵣ l′ l< ⊢Γ)
 U-elim (ℕᵣ D) = ⊥-elim (U≢ℕ (whnfRed* (red D) Uₙ))
+U-elim (Emptyᵣ D) = ⊥-elim (U≢Empty (whnfRed* (red D) Uₙ))
 U-elim (ne′ K D neK K≡K) = ⊥-elim (U≢ne neK (whnfRed* (red D) Uₙ))
 U-elim (Πᵣ′ F G D ⊢F ⊢G A≡A [F] [G] G-ext) = ⊥-elim (U≢Π (whnfRed* (red D) Uₙ))
 U-elim (emb 0<1 x) with U-elim x
@@ -71,6 +79,8 @@ U-elim (emb 0<1 x) | emb () x₁
   ⊥-elim (ℕ≢ne neK (whrDet* (D , ℕₙ) (red D′ , ne neK)))
 ℕ-elim′ D (Πᵣ′ F G D′ ⊢F ⊢G A≡A [F] [G] G-ext) =
   ⊥-elim (ℕ≢Π (whrDet* (D , ℕₙ) (red D′ , Πₙ)))
+ℕ-elim′ D (Emptyᵣ D′) =
+  ⊥-elim (ℕ≢Empty (whrDet* (D , ℕₙ) (red D′ , Emptyₙ)))
 ℕ-elim′ D (emb 0<1 x) with ℕ-elim′ D x
 ℕ-elim′ D (emb 0<1 x) | noemb x₁ = emb 0<1 (noemb x₁)
 ℕ-elim′ D (emb 0<1 x) | emb () x₂
@@ -78,10 +88,27 @@ U-elim (emb 0<1 x) | emb () x₁
 ℕ-elim : ∀ {Γ l} → Γ ⊩⟨ l ⟩ ℕ → Γ ⊩⟨ l ⟩ℕ ℕ
 ℕ-elim [ℕ] = ℕ-elim′ (id (escape [ℕ])) [ℕ]
 
+Empty-elim′ : ∀ {A Γ l} → Γ ⊢ A ⇒* Empty → Γ ⊩⟨ l ⟩ A → Γ ⊩⟨ l ⟩Empty A
+Empty-elim′ D (Uᵣ′ l′ l< ⊢Γ) = ⊥-elim (U≢Empty (whrDet* (id (Uⱼ ⊢Γ) , Uₙ) (D , Emptyₙ)))
+Empty-elim′ D (Emptyᵣ D′) = noemb D′
+Empty-elim′ D (ne′ K D′ neK K≡K) =
+  ⊥-elim (Empty≢ne neK (whrDet* (D , Emptyₙ) (red D′ , ne neK)))
+Empty-elim′ D (Πᵣ′ F G D′ ⊢F ⊢G A≡A [F] [G] G-ext) =
+  ⊥-elim (Empty≢Π (whrDet* (D , Emptyₙ) (red D′ , Πₙ)))
+Empty-elim′ D (ℕᵣ D′) =
+  ⊥-elim (Empty≢ℕ (whrDet* (D , Emptyₙ) (red D′ , ℕₙ)))
+Empty-elim′ D (emb 0<1 x) with Empty-elim′ D x
+Empty-elim′ D (emb 0<1 x) | noemb x₁ = emb 0<1 (noemb x₁)
+Empty-elim′ D (emb 0<1 x) | emb () x₂
+
+Empty-elim : ∀ {Γ l} → Γ ⊩⟨ l ⟩ Empty → Γ ⊩⟨ l ⟩Empty Empty
+Empty-elim [Empty] = Empty-elim′ (id (escape [Empty])) [Empty]
+
 ne-elim′ : ∀ {A Γ l K} → Γ ⊢ A ⇒* K → Neutral K → Γ ⊩⟨ l ⟩ A → Γ ⊩⟨ l ⟩ne A
 ne-elim′ D neK (Uᵣ′ l′ l< ⊢Γ) =
   ⊥-elim (U≢ne neK (whrDet* (id (Uⱼ ⊢Γ) , Uₙ) (D , ne neK)))
 ne-elim′ D neK (ℕᵣ D′) = ⊥-elim (ℕ≢ne neK (whrDet* (red D′ , ℕₙ) (D , ne neK)))
+ne-elim′ D neK (Emptyᵣ D′) = ⊥-elim (Empty≢ne neK (whrDet* (red D′ , Emptyₙ) (D , ne neK)))
 ne-elim′ D neK (ne′ K D′ neK′ K≡K) = noemb (ne K D′ neK′ K≡K)
 ne-elim′ D neK (Πᵣ′ F G D′ ⊢F ⊢G A≡A [F] [G] G-ext) =
   ⊥-elim (Π≢ne neK (whrDet* (red D′ , Πₙ) (D , ne neK)))
@@ -95,6 +122,7 @@ ne-elim neK [K] = ne-elim′ (id (escape [K])) neK [K]
 Π-elim′ : ∀ {A Γ F G l} → Γ ⊢ A ⇒* Π F ▹ G → Γ ⊩⟨ l ⟩ A → Γ ⊩⟨ l ⟩Π A
 Π-elim′ D (Uᵣ′ l′ l< ⊢Γ) = ⊥-elim (U≢Π (whrDet* (id (Uⱼ ⊢Γ) , Uₙ) (D , Πₙ)))
 Π-elim′ D (ℕᵣ D′) = ⊥-elim (ℕ≢Π (whrDet* (red D′ , ℕₙ) (D , Πₙ)))
+Π-elim′ D (Emptyᵣ D′) = ⊥-elim (Empty≢Π (whrDet* (red D′ , Emptyₙ) (D , Πₙ)))
 Π-elim′ D (ne′ K D′ neK K≡K) =
   ⊥-elim (Π≢ne neK (whrDet* (D , Πₙ) (red D′ , ne neK)))
 Π-elim′ D (Πᵣ′ F G D′ ⊢F ⊢G A≡A [F] [G] G-ext) =
@@ -115,6 +143,7 @@ extractMaybeEmb (emb 0<1 x) = extractMaybeEmb x
 data ShapeView Γ : ∀ l l′ A B (p : Γ ⊩⟨ l ⟩ A) (q : Γ ⊩⟨ l′ ⟩ B) → Set where
   Uᵥ : ∀ {l l′} UA UB → ShapeView Γ l l′ U U (Uᵣ UA) (Uᵣ UB)
   ℕᵥ : ∀ {A B l l′} ℕA ℕB → ShapeView Γ l l′ A B (ℕᵣ ℕA) (ℕᵣ ℕB)
+  Emptyᵥ : ∀ {A B l l′} EmptyA EmptyB → ShapeView Γ l l′ A B (Emptyᵣ EmptyA) (Emptyᵣ EmptyB)
   ne  : ∀ {A B l l′} neA neB
       → ShapeView Γ l l′ A B (ne neA) (ne neB)
   Πᵥ : ∀ {A B l l′} ΠA ΠB
@@ -131,19 +160,32 @@ goodCases : ∀ {l l′ Γ A B} ([A] : Γ ⊩⟨ l ⟩ A) ([B] : Γ ⊩⟨ l′ 
           → Γ ⊩⟨ l ⟩ A ≡ B / [A] → ShapeView Γ l l′ A B [A] [B]
 goodCases (Uᵣ UA) (Uᵣ UB) A≡B = Uᵥ UA UB
 goodCases (Uᵣ′ _ _ ⊢Γ) (ℕᵣ D) PE.refl = ⊥-elim (U≢ℕ (whnfRed* (red D) Uₙ))
+goodCases (Uᵣ′ _ _ ⊢Γ) (Emptyᵣ D) PE.refl = ⊥-elim (U≢Empty (whnfRed* (red D) Uₙ))
 goodCases (Uᵣ′ _ _ ⊢Γ) (ne′ K D neK K≡K) PE.refl = ⊥-elim (U≢ne neK (whnfRed* (red D) Uₙ))
 goodCases (Uᵣ′ _ _ ⊢Γ) (Πᵣ′ F G D ⊢F ⊢G A≡A [F] [G] G-ext) PE.refl =
   ⊥-elim (U≢Π (whnfRed* (red D) Uₙ))
 goodCases (ℕᵣ D) (Uᵣ ⊢Γ) A≡B = ⊥-elim (U≢ℕ (whnfRed* A≡B Uₙ))
+goodCases (ℕᵣ _) (Emptyᵣ D') D =
+  ⊥-elim (ℕ≢Empty (whrDet* (D , ℕₙ) (red D' , Emptyₙ)))
 goodCases (ℕᵣ ℕA) (ℕᵣ ℕB) A≡B = ℕᵥ ℕA ℕB
 goodCases (ℕᵣ D) (ne′ K D₁ neK K≡K) A≡B =
   ⊥-elim (ℕ≢ne neK (whrDet* (A≡B , ℕₙ) (red D₁ , ne neK)))
 goodCases (ℕᵣ D) (Πᵣ′ F G D₁ ⊢F ⊢G A≡A [F] [G] G-ext) A≡B =
   ⊥-elim (ℕ≢Π (whrDet* (A≡B , ℕₙ) (red D₁ , Πₙ)))
+goodCases (Emptyᵣ D) (Uᵣ ⊢Γ) A≡B = ⊥-elim (U≢Empty (whnfRed* A≡B Uₙ))
+goodCases (Emptyᵣ _) (ℕᵣ D') D =
+  ⊥-elim (ℕ≢Empty (whrDet* (red D' , ℕₙ) (D , Emptyₙ)))
+goodCases (Emptyᵣ EmptyA) (Emptyᵣ EmptyB) A≡B = Emptyᵥ EmptyA EmptyB
+goodCases (Emptyᵣ D) (ne′ K D₁ neK K≡K) A≡B =
+  ⊥-elim (Empty≢ne neK (whrDet* (A≡B , Emptyₙ) (red D₁ , ne neK)))
+goodCases (Emptyᵣ D) (Πᵣ′ F G D₁ ⊢F ⊢G A≡A [F] [G] G-ext) A≡B =
+  ⊥-elim (Empty≢Π (whrDet* (A≡B , Emptyₙ) (red D₁ , Πₙ)))
 goodCases (ne′ K D neK K≡K) (Uᵣ ⊢Γ) (ne₌ M D′ neM K≡M) =
   ⊥-elim (U≢ne neM (whnfRed* (red D′) Uₙ))
 goodCases (ne′ K D neK K≡K) (ℕᵣ D₁) (ne₌ M D′ neM K≡M) =
   ⊥-elim (ℕ≢ne neM (whrDet* (red D₁ , ℕₙ) (red D′ , ne neM)))
+goodCases (ne′ K D neK K≡K) (Emptyᵣ D₁) (ne₌ M D′ neM K≡M) =
+  ⊥-elim (Empty≢ne neM (whrDet* (red D₁ , Emptyₙ) (red D′ , ne neM)))
 goodCases (ne neA) (ne neB) A≡B = ne neA neB
 goodCases (ne′ K D neK K≡K) (Πᵣ′ F G D₁ ⊢F ⊢G A≡A [F] [G] G-ext) (ne₌ M D′ neM K≡M) =
   ⊥-elim (Π≢ne neM (whrDet* (red D₁ , Πₙ) (red D′ , ne neM)))
@@ -153,6 +195,9 @@ goodCases (Πᵣ′ F G D ⊢F ⊢G A≡A [F] [G] G-ext) (Uᵣ ⊢Γ)
 goodCases (Πᵣ′ F G D ⊢F ⊢G A≡A [F] [G] G-ext) (ℕᵣ D₁)
           (Π₌ F′ G′ D′ A≡B [F≡F′] [G≡G′]) =
   ⊥-elim (ℕ≢Π (whrDet* (red D₁ , ℕₙ) (D′ , Πₙ)))
+goodCases (Πᵣ′ F G D ⊢F ⊢G A≡A [F] [G] G-ext) (Emptyᵣ D₁)
+          (Π₌ F′ G′ D′ A≡B [F≡F′] [G≡G′]) =
+  ⊥-elim (Empty≢Π (whrDet* (red D₁ , Emptyₙ) (D′ , Πₙ)))
 goodCases (Πᵣ′ F G D ⊢F ⊢G A≡A [F] [G] G-ext) (ne′ K D₁ neK K≡K)
           (Π₌ F′ G′ D′ A≡B [F≡F′] [G≡G′]) =
   ⊥-elim (Π≢ne neK (whrDet* (D′ , Πₙ) (red D₁ , ne neK)))
@@ -176,6 +221,8 @@ data ShapeView₃ Γ : ∀ l l′ l″ A B C
   Uᵥ : ∀ {l l′ l″} UA UB UC → ShapeView₃ Γ l l′ l″ U U U (Uᵣ UA) (Uᵣ UB) (Uᵣ UC)
   ℕᵥ : ∀ {A B C l l′ l″} ℕA ℕB ℕC
     → ShapeView₃ Γ l l′ l″ A B C (ℕᵣ ℕA) (ℕᵣ ℕB) (ℕᵣ ℕC)
+  Emptyᵥ : ∀ {A B C l l′ l″} EmptyA EmptyB EmptyC
+    → ShapeView₃ Γ l l′ l″ A B C (Emptyᵣ EmptyA) (Emptyᵣ EmptyB) (Emptyᵣ EmptyC)
   ne  : ∀ {A B C l l′ l″} neA neB neC
       → ShapeView₃ Γ l l′ l″ A B C (ne neA) (ne neB) (ne neC)
   Πᵥ : ∀ {A B C l l′ l″} ΠA ΠB ΠC
@@ -197,20 +244,33 @@ combine : ∀ {Γ l l′ l″ l‴ A B C [A] [B] [B]′ [C]}
         → ShapeView₃ Γ l l′ l‴ A B C [A] [B] [C]
 combine (Uᵥ UA₁ UB₁) (Uᵥ UA UB) = Uᵥ UA₁ UB₁ UB
 combine (Uᵥ UA UB) (ℕᵥ ℕA ℕB) = ⊥-elim (U≢ℕ (whnfRed* (red ℕA) Uₙ))
+combine (Uᵥ UA UB) (Emptyᵥ EmptyA EmptyB) = ⊥-elim (U≢Empty (whnfRed* (red EmptyA) Uₙ))
 combine (Uᵥ UA UB) (ne (ne K D neK K≡K) neB) =
   ⊥-elim (U≢ne neK (whnfRed* (red D) Uₙ))
 combine (Uᵥ UA UB) (Πᵥ (Πᵣ F G D ⊢F ⊢G A≡A [F] [G] G-ext) ΠB) =
   ⊥-elim (U≢Π (whnfRed* (red D) Uₙ))
 combine (ℕᵥ ℕA ℕB) (Uᵥ UA UB) = ⊥-elim (U≢ℕ (whnfRed* (red ℕB) Uₙ))
+combine (ℕᵥ ℕA ℕB) (Emptyᵥ EmptyA EmptyB) =
+  ⊥-elim (ℕ≢Empty (whrDet* (red ℕB , ℕₙ) (red EmptyA , Emptyₙ)))
 combine (ℕᵥ ℕA₁ ℕB₁) (ℕᵥ ℕA ℕB) = ℕᵥ ℕA₁ ℕB₁ ℕB
 combine (ℕᵥ ℕA ℕB) (ne (ne K D neK K≡K) neB) =
   ⊥-elim (ℕ≢ne neK (whrDet* (red ℕB , ℕₙ) (red D , ne neK)))
 combine (ℕᵥ ℕA ℕB) (Πᵥ (Πᵣ F G D ⊢F ⊢G A≡A [F] [G] G-ext) ΠB) =
   ⊥-elim (ℕ≢Π (whrDet* (red ℕB , ℕₙ) (red D , Πₙ)))
+combine (Emptyᵥ EmptyA EmptyB) (Uᵥ UA UB) = ⊥-elim (U≢Empty (whnfRed* (red EmptyB) Uₙ))
+combine (Emptyᵥ EmptyA EmptyB) (ℕᵥ ℕA ℕB) =
+  ⊥-elim (Empty≢ℕ (whrDet* (red EmptyB , Emptyₙ) (red ℕA , ℕₙ)))
+combine (Emptyᵥ EmptyA₁ EmptyB₁) (Emptyᵥ EmptyA EmptyB) = Emptyᵥ EmptyA₁ EmptyB₁ EmptyB
+combine (Emptyᵥ EmptyA EmptyB) (ne (ne K D neK K≡K) neB) =
+  ⊥-elim (Empty≢ne neK (whrDet* (red EmptyB , Emptyₙ) (red D , ne neK)))
+combine (Emptyᵥ EmptyA EmptyB) (Πᵥ (Πᵣ F G D ⊢F ⊢G A≡A [F] [G] G-ext) ΠB) =
+  ⊥-elim (Empty≢Π (whrDet* (red EmptyB , Emptyₙ) (red D , Πₙ)))
 combine (ne neA (ne K D neK K≡K)) (Uᵥ UA UB) =
   ⊥-elim (U≢ne neK (whnfRed* (red D) Uₙ))
 combine (ne neA (ne K D neK K≡K)) (ℕᵥ ℕA ℕB) =
   ⊥-elim (ℕ≢ne neK (whrDet* (red ℕA , ℕₙ) (red D , ne neK)))
+combine (ne neA (ne K D neK K≡K)) (Emptyᵥ EmptyA EmptyB) =
+  ⊥-elim (Empty≢ne neK (whrDet* (red EmptyA , Emptyₙ) (red D , ne neK)))
 combine (ne neA₁ neB₁) (ne neA neB) = ne neA₁ neB₁ neB
 combine (ne neA (ne K D₁ neK K≡K)) (Πᵥ (Πᵣ F G D ⊢F ⊢G A≡A [F] [G] G-ext) ΠB) =
   ⊥-elim (Π≢ne neK (whrDet* (red D , Πₙ) (red D₁ , ne neK)))
@@ -218,6 +278,8 @@ combine (Πᵥ ΠA (Πᵣ F G D ⊢F ⊢G A≡A [F] [G] G-ext)) (Uᵥ UA UB) =
   ⊥-elim (U≢Π (whnfRed* (red D) Uₙ))
 combine (Πᵥ ΠA (Πᵣ F G D ⊢F ⊢G A≡A [F] [G] G-ext)) (ℕᵥ ℕA ℕB) =
   ⊥-elim (ℕ≢Π (whrDet* (red ℕA , ℕₙ) (red D , Πₙ)))
+combine (Πᵥ ΠA (Πᵣ F G D ⊢F ⊢G A≡A [F] [G] G-ext)) (Emptyᵥ EmptyA EmptyB) =
+  ⊥-elim (Empty≢Π (whrDet* (red EmptyA , Emptyₙ) (red D , Πₙ)))
 combine (Πᵥ ΠA (Πᵣ F G D₁ ⊢F ⊢G A≡A [F] [G] G-ext)) (ne (ne K D neK K≡K) neB) =
   ⊥-elim (Π≢ne neK (whrDet* (red D₁ , Πₙ) (red D , ne neK)))
 combine (Πᵥ ΠA₁ ΠB₁) (Πᵥ ΠA ΠB) = Πᵥ ΠA₁ ΠB₁ ΠB

--- a/Definition/LogicalRelation/Substitution/Introductions.agda
+++ b/Definition/LogicalRelation/Substitution/Introductions.agda
@@ -8,6 +8,8 @@ open import Definition.LogicalRelation.Substitution.Introductions.Application pu
 open import Definition.LogicalRelation.Substitution.Introductions.Lambda public
 open import Definition.LogicalRelation.Substitution.Introductions.Nat public
 open import Definition.LogicalRelation.Substitution.Introductions.Natrec public
+open import Definition.LogicalRelation.Substitution.Introductions.Empty public
+open import Definition.LogicalRelation.Substitution.Introductions.Emptyrec public
 open import Definition.LogicalRelation.Substitution.Introductions.Pi public
 open import Definition.LogicalRelation.Substitution.Introductions.SingleSubst public
 open import Definition.LogicalRelation.Substitution.Introductions.Universe public

--- a/Definition/LogicalRelation/Substitution/Introductions/Empty.agda
+++ b/Definition/LogicalRelation/Substitution/Introductions/Empty.agda
@@ -1,0 +1,31 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Definition.Typed.EqualityRelation
+
+module Definition.LogicalRelation.Substitution.Introductions.Empty {{eqrel : EqRelSet}} where
+open EqRelSet {{...}}
+
+open import Definition.Untyped
+open import Definition.Typed
+open import Definition.Typed.Properties
+open import Definition.LogicalRelation
+open import Definition.LogicalRelation.Properties
+open import Definition.LogicalRelation.Substitution
+open import Definition.LogicalRelation.Substitution.Introductions.Universe
+
+open import Tools.Unit
+open import Tools.Product
+
+
+-- Validity of the Empty type.
+Emptyᵛ : ∀ {Γ l} ([Γ] : ⊩ᵛ Γ) → Γ ⊩ᵛ⟨ l ⟩ Empty / [Γ]
+Emptyᵛ [Γ] ⊢Δ [σ] = Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ)) , λ _ x₂ → id (Emptyⱼ ⊢Δ)
+
+-- Validity of the Empty type as a term.
+Emptyᵗᵛ : ∀ {Γ} ([Γ] : ⊩ᵛ Γ)
+    → Γ ⊩ᵛ⟨ ¹ ⟩ Empty ∷ U / [Γ] / Uᵛ [Γ]
+Emptyᵗᵛ [Γ] ⊢Δ [σ] = let ⊢Empty  = Emptyⱼ ⊢Δ
+                         [Empty] = Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ))
+                 in  Uₜ Empty (idRedTerm:*: ⊢Empty) Emptyₙ (≅ₜ-Emptyrefl ⊢Δ) [Empty]
+                 ,   (λ x x₁ → Uₜ₌ Empty Empty (idRedTerm:*: ⊢Empty) (idRedTerm:*: ⊢Empty) Emptyₙ Emptyₙ
+                                   (≅ₜ-Emptyrefl ⊢Δ) [Empty] [Empty] (id (Emptyⱼ ⊢Δ)))

--- a/Definition/LogicalRelation/Substitution/Introductions/Emptyrec.agda
+++ b/Definition/LogicalRelation/Substitution/Introductions/Emptyrec.agda
@@ -1,0 +1,182 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Definition.Typed.EqualityRelation
+
+module Definition.LogicalRelation.Substitution.Introductions.Emptyrec {{eqrel : EqRelSet}} where
+open EqRelSet {{...}}
+
+open import Definition.Untyped as U hiding (wk)
+open import Definition.Untyped.Properties
+open import Definition.Typed
+import Definition.Typed.Weakening as T
+open import Definition.Typed.Properties
+open import Definition.Typed.RedSteps
+open import Definition.LogicalRelation
+open import Definition.LogicalRelation.ShapeView
+open import Definition.LogicalRelation.Irrelevance
+open import Definition.LogicalRelation.Properties
+open import Definition.LogicalRelation.Application
+open import Definition.LogicalRelation.Substitution
+open import Definition.LogicalRelation.Substitution.Properties
+import Definition.LogicalRelation.Substitution.Irrelevance as S
+open import Definition.LogicalRelation.Substitution.Reflexivity
+open import Definition.LogicalRelation.Substitution.Weakening
+open import Definition.LogicalRelation.Substitution.Introductions.Empty
+open import Definition.LogicalRelation.Substitution.Introductions.Pi
+open import Definition.LogicalRelation.Substitution.Introductions.SingleSubst
+
+open import Tools.Product
+open import Tools.Unit
+open import Tools.Empty
+open import Tools.Nat
+
+import Tools.PropositionalEquality as PE
+
+
+-- Natural recursion closure reduction (requires reducible terms and equality).
+Emptyrec-subst* : ∀ {Γ C n n′ l}
+              → Γ ⊢ C
+              → Γ ⊢ n ⇒* n′ ∷ Empty
+              → ([Empty] : Γ ⊩⟨ l ⟩ Empty)
+              → Γ ⊩⟨ l ⟩ n′ ∷ Empty / [Empty]
+              → Γ ⊢ Emptyrec C n ⇒* Emptyrec C n′ ∷ C
+Emptyrec-subst* C (id x) [Empty] [n′] = id (Emptyrecⱼ C x)
+Emptyrec-subst* C (x ⇨ n⇒n′) [Empty] [n′] =
+  let q , w = redSubst*Term n⇒n′ [Empty] [n′]
+      a , s = redSubstTerm x [Empty] q
+  in  Emptyrec-subst C x ⇨ conv* (Emptyrec-subst* C n⇒n′ [Empty] [n′]) (refl C)
+
+-- Reducibility of natural recursion under a valid substitution.
+EmptyrecTerm : ∀ {F n Γ Δ σ l}
+             ([Γ]  : ⊩ᵛ Γ)
+             ([F]  : Γ ⊩ᵛ⟨ l ⟩ F / [Γ])
+             (⊢Δ   : ⊢ Δ)
+             ([σ]  : Δ ⊩ˢ σ ∷ Γ / [Γ] / ⊢Δ)
+             ([σn] : Δ ⊩⟨ l ⟩ n ∷ Empty / Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ)))
+           → Δ ⊩⟨ l ⟩ Emptyrec (subst σ F) n
+               ∷ subst σ F
+               / proj₁ ([F] ⊢Δ [σ])
+EmptyrecTerm {F} {n} {Γ} {Δ} {σ} {l} [Γ] [F] ⊢Δ [σ]
+           (Emptyₜ m d n≡n (ne (neNfₜ neM ⊢m m≡m))) =
+  let [Empty] = Emptyᵛ {l = l} [Γ]
+      [σEmpty] = proj₁ ([Empty] ⊢Δ [σ])
+      [σm] = neuTerm [σEmpty] neM ⊢m m≡m
+      [σF] = proj₁ ([F] ⊢Δ [σ])
+      ⊢F = escape [σF]
+      ⊢F≡F = escapeEq [σF] (reflEq [σF])
+      EmptyrecM = neuTerm [σF] (Emptyrecₙ neM) (Emptyrecⱼ ⊢F ⊢m)
+                        (~-Emptyrec ⊢F≡F m≡m)
+      reduction = Emptyrec-subst* ⊢F (redₜ d) [σEmpty] [σm]
+  in proj₁ (redSubst*Term reduction [σF] EmptyrecM)
+
+
+-- Reducibility of natural recursion congurence under a valid substitution equality.
+Emptyrec-congTerm : ∀ {F F′ n m Γ Δ σ σ′ l}
+                  ([Γ]      : ⊩ᵛ Γ)
+                  ([F]      : Γ ⊩ᵛ⟨ l ⟩ F / [Γ])
+                  ([F′]     : Γ ⊩ᵛ⟨ l ⟩ F′ / [Γ])
+                  ([F≡F′]   : Γ ⊩ᵛ⟨ l ⟩ F ≡ F′ / [Γ] / [F])
+                  (⊢Δ       : ⊢ Δ)
+                  ([σ]      : Δ ⊩ˢ σ  ∷ Γ / [Γ] / ⊢Δ)
+                  ([σ′]     : Δ ⊩ˢ σ′ ∷ Γ / [Γ] / ⊢Δ)
+                  ([σ≡σ′]   : Δ ⊩ˢ σ ≡ σ′ ∷ Γ / [Γ] / ⊢Δ / [σ])
+                  ([σn]     : Δ ⊩⟨ l ⟩ n ∷ Empty / Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ)))
+                  ([σm]     : Δ ⊩⟨ l ⟩ m ∷ Empty / Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ)))
+                  ([σn≡σm]  : Δ ⊩⟨ l ⟩ n ≡ m ∷ Empty / Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ)))
+                → Δ ⊩⟨ l ⟩ Emptyrec (subst σ F) n
+                    ≡ Emptyrec (subst σ′ F′) m
+                    ∷ subst σ F
+                    / proj₁ ([F] ⊢Δ [σ])
+Emptyrec-congTerm {F} {F′} {n} {m} {Γ} {Δ} {σ} {σ′} {l}
+                [Γ] [F] [F′] [F≡F′]
+                ⊢Δ [σ] [σ′] [σ≡σ′]
+                (Emptyₜ n′ d n≡n (ne (neNfₜ neN′ ⊢n′ n≡n₁)))
+                (Emptyₜ m′ d′ m≡m (ne (neNfₜ neM′ ⊢m′ m≡m₁)))
+                (Emptyₜ₌ n″ m″ d₁ d₁′ t≡u (ne (neNfₜ₌ x₂ x₃ prop₂))) =
+  let n″≡n′ = whrDet*Term (redₜ d₁ , ne x₂) (redₜ d , ne neN′)
+      m″≡m′ = whrDet*Term (redₜ d₁′ , ne x₃) (redₜ d′ , ne neM′)
+      [Empty] = Emptyᵛ {l = l} [Γ]
+      [σEmpty] = proj₁ ([Empty] ⊢Δ [σ])
+      [σ′Empty] = proj₁ ([Empty] ⊢Δ [σ′])
+      [σF] = proj₁ ([F] ⊢Δ [σ])
+      [σ′F] = proj₁ ([F] ⊢Δ [σ′])
+      [σ′F′] = proj₁ ([F′] ⊢Δ [σ′])
+      [σn′] = neuTerm [σEmpty] neN′ ⊢n′ n≡n₁
+      [σ′m′] = neuTerm [σ′Empty] neM′ ⊢m′ m≡m₁
+      ⊢F = escape [σF]
+      ⊢F≡F = escapeEq [σF] (reflEq [σF])
+      ⊢F′ = escape [σ′F′]
+      ⊢F′≡F′ = escapeEq [σ′F′] (reflEq [σ′F′])
+      ⊢σF≡σ′F = escapeEq [σF] (proj₂ ([F] ⊢Δ [σ]) [σ′] [σ≡σ′])
+      ⊢σ′F≡σ′F′ = escapeEq [σ′F] ([F≡F′] ⊢Δ [σ′])
+      ⊢F≡F′ = ≅-trans ⊢σF≡σ′F ⊢σ′F≡σ′F′
+      [σF≡σ′F] = proj₂ ([F] ⊢Δ [σ]) [σ′] [σ≡σ′]
+      [σ′F≡σ′F′] = [F≡F′] ⊢Δ [σ′]
+      [σF≡σ′F′] = transEq [σF] [σ′F] [σ′F′] [σF≡σ′F] [σ′F≡σ′F′]
+      EmptyrecN = neuTerm [σF] (Emptyrecₙ neN′) (Emptyrecⱼ ⊢F ⊢n′)
+                        (~-Emptyrec ⊢F≡F n≡n₁)
+      EmptyrecM = neuTerm [σ′F′] (Emptyrecₙ neM′) (Emptyrecⱼ ⊢F′ ⊢m′)
+                        (~-Emptyrec ⊢F′≡F′ m≡m₁)
+      EmptyrecN≡M =
+          (neuEqTerm [σF] (Emptyrecₙ neN′) (Emptyrecₙ neM′)
+                     (Emptyrecⱼ ⊢F ⊢n′)
+                     (conv (Emptyrecⱼ ⊢F′ ⊢m′)
+                            (sym (≅-eq (escapeEq [σF]
+                              (transEq [σF] [σ′F] [σ′F′] [σF≡σ′F] [σ′F≡σ′F′])))))
+                     (~-Emptyrec ⊢F≡F′
+                               (PE.subst₂ (λ x y → _ ⊢ x ~ y ∷ _)
+                                          n″≡n′ m″≡m′ prop₂)))
+      reduction₁ = Emptyrec-subst* ⊢F (redₜ d) [σEmpty] [σn′]
+      reduction₂ = Emptyrec-subst* ⊢F′ (redₜ d′) [σ′Empty] [σ′m′]
+      eq₁ = proj₂ (redSubst*Term reduction₁ [σF] EmptyrecN)
+      eq₂ = proj₂ (redSubst*Term reduction₂ [σ′F′] EmptyrecM)
+  in transEqTerm [σF] eq₁
+                 (transEqTerm [σF] EmptyrecN≡M
+                              (convEqTerm₂ [σF] [σ′F′] [σF≡σ′F′]
+                                           (symEqTerm [σ′F′] eq₂)))
+
+
+
+-- Validity of empty recursion.
+Emptyrecᵛ : ∀ {F n Γ l} ([Γ] : ⊩ᵛ Γ)
+          ([Empty]  : Γ ⊩ᵛ⟨ l ⟩ Empty / [Γ])
+          ([F]  : Γ ⊩ᵛ⟨ l ⟩ F / [Γ])
+        → ([n] : Γ ⊩ᵛ⟨ l ⟩ n ∷ Empty / [Γ] / [Empty])
+        → Γ ⊩ᵛ⟨ l ⟩ Emptyrec F n ∷ F / [Γ] / [F]
+Emptyrecᵛ {F} {n} {l = l} [Γ] [Empty] [F] [n]
+        {Δ = Δ} {σ = σ} ⊢Δ [σ] =
+  let [σn] = irrelevanceTerm {l′ = l} (proj₁ ([Empty] ⊢Δ [σ]))
+                             (Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ))) (proj₁ ([n] ⊢Δ [σ]))
+  in EmptyrecTerm {F = F} [Γ] [F] ⊢Δ [σ] [σn]
+    , λ {σ'} [σ′] [σ≡σ′] →
+      let [σ′n] = irrelevanceTerm {l′ = l} (proj₁ ([Empty] ⊢Δ [σ′]))
+                                  (Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ))) (proj₁ ([n] ⊢Δ [σ′]))
+          [σn≡σ′n] = irrelevanceEqTerm {l′ = l} (proj₁ ([Empty] ⊢Δ [σ]))
+                                       (Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ)))
+                                       (proj₂ ([n] ⊢Δ [σ]) [σ′] [σ≡σ′])
+          congTerm = Emptyrec-congTerm {F = F} {F′ = F} [Γ] [F] [F] (reflᵛ {F} {l = l} [Γ] [F])
+                                       ⊢Δ [σ] [σ′] [σ≡σ′] [σn] [σ′n] [σn≡σ′n]
+      in congTerm
+
+-- Validity of natural recursion congurence.
+Emptyrec-congᵛ : ∀ {F F′ n n′ Γ l} ([Γ] : ⊩ᵛ Γ)
+          ([Empty]  : Γ ⊩ᵛ⟨ l ⟩ Empty / [Γ])
+          ([F]  : Γ ⊩ᵛ⟨ l ⟩ F / [Γ])
+          ([F′]  : Γ ⊩ᵛ⟨ l ⟩ F′ / [Γ])
+          ([F≡F′]  : Γ ⊩ᵛ⟨ l ⟩ F ≡ F′ / [Γ] / [F])
+          ([n] : Γ ⊩ᵛ⟨ l ⟩ n ∷ Empty / [Γ] / [Empty])
+          ([n′] : Γ ⊩ᵛ⟨ l ⟩ n′ ∷ Empty / [Γ] / [Empty])
+          ([n≡n′] : Γ ⊩ᵛ⟨ l ⟩ n ≡ n′ ∷ Empty / [Γ] / [Empty])
+        → Γ ⊩ᵛ⟨ l ⟩ Emptyrec F n ≡ Emptyrec F′ n′ ∷ F / [Γ] / [F]
+Emptyrec-congᵛ {F} {F′} {n} {n′} {l = l}
+             [Γ] [Empty] [F] [F′] [F≡F′]
+             [n] [n′] [n≡n′] {Δ = Δ} {σ = σ} ⊢Δ [σ] =
+  let [σn] = irrelevanceTerm {l′ = l} (proj₁ ([Empty] ⊢Δ [σ]))
+                             (Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ))) (proj₁ ([n] ⊢Δ [σ]))
+      [σn′] = irrelevanceTerm {l′ = l} (proj₁ ([Empty] ⊢Δ [σ]))
+                             (Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ))) (proj₁ ([n′] ⊢Δ [σ]))
+      [σn≡σn′] = irrelevanceEqTerm {l′ = l} (proj₁ ([Empty] ⊢Δ [σ]))
+                                   (Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ))) ([n≡n′] ⊢Δ [σ])
+      congTerm = Emptyrec-congTerm {F} {F′} [Γ] [F] [F′] [F≡F′]
+                                   ⊢Δ [σ] [σ] (reflSubst [Γ] ⊢Δ [σ]) [σn] [σn′] [σn≡σn′]
+  in congTerm

--- a/Definition/LogicalRelation/Weakening.agda
+++ b/Definition/LogicalRelation/Weakening.agda
@@ -61,11 +61,34 @@ mutual
   wk[Natural]-prop ρ ⊢Δ zeroᵣ = zeroᵣ
   wk[Natural]-prop ρ ⊢Δ (ne x) = ne (wkEqTermNe ρ ⊢Δ x)
 
+-- Empty
+wkTermEmpty : ∀ {ρ Γ Δ n} → ρ ∷ Δ ⊆ Γ → (⊢Δ : ⊢ Δ)
+  → Γ ⊩Empty n ∷Empty → Δ ⊩Empty U.wk ρ n ∷Empty
+wkTermEmpty {ρ} [ρ] ⊢Δ (Emptyₜ n d n≡n (ne prop)) =
+  Emptyₜ (U.wk ρ n) (wkRed:*:Term [ρ] ⊢Δ d)
+     (≅ₜ-wk [ρ] ⊢Δ n≡n)
+     (ne (wkTermNe [ρ] ⊢Δ prop))
+
+wk[Empty]-prop : ∀ {ρ Γ Δ n n′} → ρ ∷ Δ ⊆ Γ → (⊢Δ : ⊢ Δ)
+  → [Empty]-prop Γ n n′
+  → [Empty]-prop Δ (U.wk ρ n) (U.wk ρ n′)
+wk[Empty]-prop ρ ⊢Δ (ne x) = ne (wkEqTermNe ρ ⊢Δ x)
+
+wkEqTermEmpty : ∀ {ρ Γ Δ t u} → ρ ∷ Δ ⊆ Γ → (⊢Δ : ⊢ Δ)
+  → Γ ⊩Empty t ≡ u ∷Empty
+  → Δ ⊩Empty U.wk ρ t ≡ U.wk ρ u ∷Empty
+wkEqTermEmpty {ρ} [ρ] ⊢Δ (Emptyₜ₌ k k′ d d′ t≡u prop) =
+  Emptyₜ₌ (U.wk ρ k) (U.wk ρ k′) (wkRed:*:Term [ρ] ⊢Δ d)
+      (wkRed:*:Term [ρ] ⊢Δ d′) (≅ₜ-wk [ρ] ⊢Δ t≡u)
+      (wk[Empty]-prop [ρ] ⊢Δ prop)
+
+
 -- Weakening of the logical relation
 
 wk : ∀ {ρ Γ Δ A l} → ρ ∷ Δ ⊆ Γ → ⊢ Δ → Γ ⊩⟨ l ⟩ A → Δ ⊩⟨ l ⟩ U.wk ρ A
 wk ρ ⊢Δ (Uᵣ′ l′ l< ⊢Γ) = Uᵣ′ l′ l< ⊢Δ
 wk ρ ⊢Δ (ℕᵣ D) = ℕᵣ (wkRed:*: ρ ⊢Δ D)
+wk ρ ⊢Δ (Emptyᵣ D) = Emptyᵣ (wkRed:*: ρ ⊢Δ D)
 wk {ρ} [ρ] ⊢Δ (ne′ K D neK K≡K) =
   ne′ (U.wk ρ K) (wkRed:*: [ρ] ⊢Δ D) (wkNeutral ρ neK) (~-wk [ρ] ⊢Δ K≡K)
 wk {ρ} {Γ} {Δ} {A} {l} [ρ] ⊢Δ (Πᵣ′ F G D ⊢F ⊢G A≡A [F] [G] G-ext) =
@@ -114,6 +137,7 @@ wkEq : ∀ {ρ Γ Δ A B l} → ([ρ] : ρ ∷ Δ ⊆ Γ) (⊢Δ : ⊢ Δ)
      → Δ ⊩⟨ l ⟩ U.wk ρ A ≡ U.wk ρ B / wk [ρ] ⊢Δ [A]
 wkEq ρ ⊢Δ (Uᵣ′ _ _ _) PE.refl = PE.refl
 wkEq ρ ⊢Δ (ℕᵣ D) A≡B = wkRed* ρ ⊢Δ A≡B
+wkEq ρ ⊢Δ (Emptyᵣ D) A≡B = wkRed* ρ ⊢Δ A≡B
 wkEq {ρ} [ρ] ⊢Δ (ne′ _ _ _ _) (ne₌ M D′ neM K≡M) =
   ne₌ (U.wk ρ M) (wkRed:*: [ρ] ⊢Δ D′)
       (wkNeutral ρ neM) (~-wk [ρ] ⊢Δ K≡M)
@@ -147,6 +171,7 @@ wkTerm {ρ} [ρ] ⊢Δ (Uᵣ′ .⁰ 0<1 ⊢Γ) (Uₜ A d typeA A≡A [t]) =
   Uₜ (U.wk ρ A) (wkRed:*:Term [ρ] ⊢Δ d)
      (wkType ρ typeA) (≅ₜ-wk [ρ] ⊢Δ A≡A) (wk [ρ] ⊢Δ [t])
 wkTerm ρ ⊢Δ (ℕᵣ D) [t] = wkTermℕ ρ ⊢Δ [t]
+wkTerm ρ ⊢Δ (Emptyᵣ D) [t] = wkTermEmpty ρ ⊢Δ [t]
 wkTerm {ρ} [ρ] ⊢Δ (ne′ K D neK K≡K) (neₜ k d nf) =
   neₜ (U.wk ρ k) (wkRed:*:Term [ρ] ⊢Δ d) (wkTermNe [ρ] ⊢Δ nf)
 wkTerm {ρ} [ρ] ⊢Δ (Πᵣ′ F G D ⊢F ⊢G A≡A [F] [G] G-ext) (Πₜ f d funcF f≡f [f] [f]₁) =
@@ -187,6 +212,7 @@ wkEqTerm {ρ} [ρ] ⊢Δ (Uᵣ′ .⁰ 0<1 ⊢Γ) (Uₜ₌ A B d d′ typeA type
       (wkType ρ typeA) (wkType ρ typeB) (≅ₜ-wk [ρ] ⊢Δ A≡B)
       (wk [ρ] ⊢Δ [t]) (wk [ρ] ⊢Δ [u]) (wkEq [ρ] ⊢Δ [t] [t≡u])
 wkEqTerm ρ ⊢Δ (ℕᵣ D) [t≡u] = wkEqTermℕ ρ ⊢Δ [t≡u]
+wkEqTerm ρ ⊢Δ (Emptyᵣ D) [t≡u] = wkEqTermEmpty ρ ⊢Δ [t≡u]
 wkEqTerm {ρ} [ρ] ⊢Δ (ne′ K D neK K≡K) (neₜ₌ k m d d′ nf) =
   neₜ₌ (U.wk ρ k) (U.wk ρ m)
        (wkRed:*:Term [ρ] ⊢Δ d) (wkRed:*:Term [ρ] ⊢Δ d′)

--- a/Definition/Typed.agda
+++ b/Definition/Typed.agda
@@ -29,6 +29,7 @@ mutual
   -- Well-formed type
   data _⊢_ (Γ : Con Term) : Term → Set where
     ℕⱼ    : ⊢ Γ → Γ ⊢ ℕ
+    Emptyⱼ : ⊢ Γ -> Γ ⊢ Empty
     Uⱼ    : ⊢ Γ → Γ ⊢ U
     Πⱼ_▹_ : ∀ {F G}
          → Γ     ⊢ F
@@ -41,6 +42,7 @@ mutual
   -- Well-formed term of a type
   data _⊢_∷_ (Γ : Con Term) : Term → Term → Set where
     ℕⱼ      : ⊢ Γ → Γ ⊢ ℕ ∷ U
+    Emptyⱼ :  ⊢ Γ → Γ ⊢ Empty ∷ U
     Πⱼ_▹_   : ∀ {F G}
            → Γ     ⊢ F ∷ U
            → Γ ∙ F ⊢ G ∷ U
@@ -68,6 +70,8 @@ mutual
            → Γ       ⊢ s ∷ Π ℕ ▹ (G ▹▹ G [ suc (var Nat.zero) ]↑)
            → Γ       ⊢ n ∷ ℕ
            → Γ       ⊢ natrec G z s n ∷ G [ n ]
+    Emptyrecⱼ : ∀ {A e}
+           -> Γ ⊢ A -> Γ ⊢ e ∷ Empty -> Γ ⊢ Emptyrec A e ∷ A
     conv   : ∀ {t A B}
            → Γ ⊢ t ∷ A
            → Γ ⊢ A ≡ B
@@ -151,6 +155,10 @@ mutual
                 → Γ     ⊢ s ∷ Π ℕ ▹ (F ▹▹ F [ suc (var Nat.zero) ]↑)
                 → Γ     ⊢ natrec F z s (suc n) ≡ (s ∘ n) ∘ (natrec F z s n)
                         ∷ F [ suc n ]
+    Emptyrec-cong : ∀ {A A' e e'}
+                → Γ ⊢ A ≡ A'
+                → Γ ⊢ e ≡ e' ∷ Empty
+                → Γ ⊢ Emptyrec A e ≡ Emptyrec A' e' ∷ A
 
 -- Term reduction
 data _⊢_⇒_∷_ (Γ : Con Term) : Term → Term → Term → Set where
@@ -185,6 +193,10 @@ data _⊢_⇒_∷_ (Γ : Con Term) : Term → Term → Term → Set where
                → Γ     ⊢ s ∷ Π ℕ ▹ (F ▹▹ F [ suc (var Nat.zero) ]↑)
                → Γ     ⊢ natrec F z s (suc n) ⇒ (s ∘ n) ∘ (natrec F z s n)
                        ∷ F [ suc n ]
+  Emptyrec-subst : ∀ {n n′ A}
+               → Γ ⊢ A
+               → Γ     ⊢ n ⇒ n′ ∷ Empty
+               → Γ     ⊢ Emptyrec A n ⇒ Emptyrec A n′ ∷ A
 
 -- Type reduction
 data _⊢_⇒_ (Γ : Con Term) : Term → Term → Set where

--- a/Definition/Typed/Consequences/Canonicity.agda
+++ b/Definition/Typed/Consequences/Canonicity.agda
@@ -48,3 +48,17 @@ canonicity : ∀ {t} → ε ⊢ t ∷ ℕ → ∃ λ k → ε ⊢ t ≡ sucᵏ k
 canonicity ⊢t with reducibleTerm ⊢t
 canonicity ⊢t | [ℕ] , [t] =
   canonicity′ (ℕ-elim [ℕ]) (irrelevanceTerm [ℕ] (ℕ-intr (ℕ-elim [ℕ])) [t])
+
+-- Canonicity for Empty
+
+¬Empty′ : ∀ {n} → ε ⊩Empty n ∷Empty → ⊥
+¬Empty′ (Emptyₜ n _ n≡n (ne (neNfₜ neN ⊢n _))) =
+  noNe ⊢n neN
+
+¬Empty : ∀ {n} → ε ⊢ n ∷ Empty → ⊥
+¬Empty {n} ⊢n =
+  let [Empty] , [n] = reducibleTerm ⊢n
+      [Empty]′ = Emptyᵣ {l = ¹} ([ Emptyⱼ ε , Emptyⱼ ε , id (Emptyⱼ ε) ])
+      [n]′ = irrelevanceTerm [Empty] [Empty]′ [n]
+
+  in ¬Empty′ [n]′

--- a/Definition/Typed/Consequences/Equality.agda
+++ b/Definition/Typed/Consequences/Equality.agda
@@ -45,6 +45,22 @@ U≡A {A} U≡A | [U] , [A] , [U≡A] =
 ℕ≡A {A} ℕ≡A whnfA | [ℕ] , [A] , [ℕ≡A] =
   ℕ≡A′ (ℕ-elim [ℕ]) (irrelevanceEq [ℕ] (ℕ-intr (ℕ-elim [ℕ])) [ℕ≡A]) whnfA
 
+-- If A in WHNF is judgmentally equal to Empty, then A is propositionally equal to Empty.
+Empty≡A′ : ∀ {A Γ l} ([Empty] : Γ ⊩⟨ l ⟩Empty Empty)
+    → Γ ⊩⟨ l ⟩ Empty ≡ A / (Empty-intr [Empty])
+    → Whnf A
+    → A PE.≡ Empty
+Empty≡A′ (noemb x) [Empty≡A] whnfA = whnfRed* [Empty≡A] whnfA
+Empty≡A′ (emb 0<1 [Empty]) [Empty≡A] whnfA = Empty≡A′ [Empty] [Empty≡A] whnfA
+
+Empty≡A : ∀ {A Γ}
+    → Γ ⊢ Empty ≡ A
+    → Whnf A
+    → A PE.≡ Empty
+Empty≡A {A} Empty≡A whnfA with reducibleEq Empty≡A
+Empty≡A {A} Empty≡A whnfA | [Empty] , [A] , [Empty≡A] =
+  Empty≡A′ (Empty-elim [Empty]) (irrelevanceEq [Empty] (Empty-intr (Empty-elim [Empty])) [Empty≡A]) whnfA
+
 ne≡A′ : ∀ {A K Γ l}
      → ([K] : Γ ⊩⟨ l ⟩ne K)
      → Γ ⊩⟨ l ⟩ K ≡ A / (ne-intr [K])

--- a/Definition/Typed/Consequences/Inequality.agda
+++ b/Definition/Typed/Consequences/Inequality.agda
@@ -48,6 +48,45 @@ U≢ℕ U≡ℕ =
   let _ , ⊢ℕ = syntacticEq U≡ℕ
   in  U≢ℕ-red (id ⊢ℕ) U≡ℕ
 
+-- U and Empty
+U≢Empty′ : ∀ {Γ B l l′}
+       ([U] : Γ ⊩′⟨ l ⟩U)
+       ([Empty] : Γ ⊩Empty B)
+     → ShapeView Γ l l′ _ _ (Uᵣ [U]) (Emptyᵣ [Empty]) → ⊥
+U≢Empty′ a b ()
+
+U≢Empty-red : ∀ {B Γ} → Γ ⊢ B ⇒* Empty → Γ ⊢ U ≡ B → ⊥
+U≢Empty-red D = A≢B (λ Γ l A → Γ ⊩′⟨ l ⟩U) (λ Γ l B → Γ ⊩Empty B) Uᵣ Emptyᵣ
+                (λ x → extractMaybeEmb (U-elim x))
+                (λ x → extractMaybeEmb (Empty-elim′ D x))
+                U≢Empty′
+
+U≢Emptyⱼ : ∀ {Γ} → Γ ⊢ U ≡ Empty → ⊥
+U≢Emptyⱼ U≡Empty =
+  let _ , ⊢Empty = syntacticEq U≡Empty
+  in  U≢Empty-red (id ⊢Empty) U≡Empty
+
+-- ℕ and Empty
+
+ℕ≢Empty′ : ∀ {Γ B l l'}
+           ([ℕ] : Γ ⊩ℕ ℕ)
+           ([Empty] : Γ ⊩Empty B)
+           → ShapeView Γ l l' _ _ (ℕᵣ [ℕ]) (Emptyᵣ [Empty]) → ⊥
+ℕ≢Empty′ a b ()
+
+ℕ≢Empty-red : ∀ {B Γ} → Γ ⊢ B ⇒* Empty → Γ ⊢ ℕ ≡ B → ⊥
+ℕ≢Empty-red D = A≢B (λ Γ l A → Γ ⊩ℕ A) (λ Γ l B → Γ ⊩Empty B) ℕᵣ Emptyᵣ
+                (λ x → extractMaybeEmb (ℕ-elim x))
+                (λ x → extractMaybeEmb (Empty-elim′ D x))
+                ℕ≢Empty′
+
+ℕ≢Emptyⱼ : ∀ {Γ} → Γ ⊢ ℕ ≡ Empty → ⊥
+ℕ≢Emptyⱼ ℕ≡Empty =
+  let _ , ⊢Empty = syntacticEq ℕ≡Empty
+  in  ℕ≢Empty-red (id ⊢Empty) ℕ≡Empty
+
+
+
 U≢Π′ : ∀ {B Γ l l′}
        ([U] : Γ ⊩′⟨ l ⟩U)
        ([Π] : Γ ⊩′⟨ l′ ⟩Π B)
@@ -104,6 +143,26 @@ U≢ne neK U≡K =
   let ⊢ℕ , ⊢Π = syntacticEq ℕ≡Π
   in  ℕ≢Π-red (id ⊢ℕ) (id ⊢Π) ℕ≡Π
 
+-- Empty and Π
+Empty≢Π′ : ∀ {A B Γ l l′}
+       ([Empty] : Γ ⊩Empty A)
+       ([Π] : Γ ⊩′⟨ l′ ⟩Π B)
+     → ShapeView Γ l l′ _ _ (Emptyᵣ [Empty]) (Πᵣ [Π]) → ⊥
+Empty≢Π′ a b ()
+
+Empty≢Π-red : ∀ {A B F G Γ} → Γ ⊢ A ⇒* Empty → Γ ⊢ B ⇒* Π F ▹ G → Γ ⊢ A ≡ B → ⊥
+Empty≢Π-red D D′ = A≢B (λ Γ l A → Γ ⊩Empty A)
+                   (λ Γ l A → Γ ⊩′⟨ l ⟩Π A) Emptyᵣ Πᵣ
+                   (λ x → extractMaybeEmb (Empty-elim′ D x))
+                   (λ x → extractMaybeEmb (Π-elim′ D′ x))
+                   Empty≢Π′
+
+Empty≢Πⱼ : ∀ {F G Γ} → Γ ⊢ Empty ≡ Π F ▹ G → ⊥
+Empty≢Πⱼ Empty≡Π =
+  let ⊢Empty , ⊢Π = syntacticEq Empty≡Π
+  in  Empty≢Π-red (id ⊢Empty) (id ⊢Π) Empty≡Π
+
+
 ℕ≢ne′ : ∀ {A K Γ l l′}
        ([ℕ] : Γ ⊩ℕ A)
        ([K] : Γ ⊩ne K)
@@ -121,6 +180,25 @@ U≢ne neK U≡K =
 ℕ≢ne neK ℕ≡K =
   let ⊢ℕ , ⊢K = syntacticEq ℕ≡K
   in  ℕ≢ne-red (id ⊢ℕ) (id ⊢K) neK ℕ≡K
+
+-- Empty and neutral
+Empty≢ne′ : ∀ {A K Γ l l′}
+       ([Empty] : Γ ⊩Empty A)
+       ([K] : Γ ⊩ne K)
+     → ShapeView Γ l l′ _ _ (Emptyᵣ [Empty]) (ne [K]) → ⊥
+Empty≢ne′ a b ()
+
+Empty≢ne-red : ∀ {A B K Γ} → Γ ⊢ A ⇒* Empty → Γ ⊢ B ⇒* K → Neutral K → Γ ⊢ A ≡ B → ⊥
+Empty≢ne-red D D′ neK = A≢B (λ Γ l A → Γ ⊩Empty A) (λ Γ l B → Γ ⊩ne B) Emptyᵣ ne
+                        (λ x → extractMaybeEmb (Empty-elim′ D x))
+                        (λ x → extractMaybeEmb (ne-elim′ D′ neK x))
+                        Empty≢ne′
+
+Empty≢neⱼ : ∀ {K Γ} → Neutral K → Γ ⊢ Empty ≡ K → ⊥
+Empty≢neⱼ neK Empty≡K =
+  let ⊢Empty , ⊢K = syntacticEq Empty≡K
+  in  Empty≢ne-red (id ⊢Empty) (id ⊢K) neK Empty≡K
+
 
 Π≢ne′ : ∀ {A K Γ l l′}
        ([Π] : Γ ⊩′⟨ l ⟩Π A)

--- a/Definition/Typed/Consequences/InverseUniv.agda
+++ b/Definition/Typed/Consequences/InverseUniv.agda
@@ -22,6 +22,7 @@ data UFull : Term → Set where
 -- Terms cannot contain U.
 noU : ∀ {t A Γ} → Γ ⊢ t ∷ A → ¬ (UFull t)
 noU (ℕⱼ x) ()
+noU (Emptyⱼ x) ()
 noU (Πⱼ t ▹ t₁) (∃Π₁ ufull) = noU t ufull
 noU (Πⱼ t ▹ t₁) (∃Π₂ ufull) = noU t₁ ufull
 noU (var x₁ x₂) ()
@@ -30,6 +31,7 @@ noU (t ∘ⱼ t₁) ()
 noU (zeroⱼ x) ()
 noU (sucⱼ t) ()
 noU (natrecⱼ x t t₁ t₂) ()
+noU (Emptyrecⱼ x t) ()
 noU (conv t₁ x) ufull = noU t₁ ufull
 
 -- Neutrals cannot contain U.
@@ -37,6 +39,7 @@ noUNe : ∀ {A} → Neutral A → ¬ (UFull A)
 noUNe (var n) ()
 noUNe (∘ₙ neA) ()
 noUNe (natrecₙ neA) ()
+noUNe (Emptyrecₙ neA) ()
 
 -- Helper function where if at least one Π-type does not contain U,
 -- one of F and H will not contain U and one of G and E will not contain U.
@@ -49,6 +52,7 @@ pilem (inj₂ x) = inj₂ (λ x₁ → x (∃Π₁ x₁)) , inj₂ (λ x₁ → 
 -- If type A does not contain U, then A can be a term of type U.
 inverseUniv : ∀ {A Γ} → ¬ (UFull A) → Γ ⊢ A → Γ ⊢ A ∷ U
 inverseUniv q (ℕⱼ x) = ℕⱼ x
+inverseUniv q (Emptyⱼ x) = Emptyⱼ x
 inverseUniv q (Uⱼ x) = ⊥-elim (q ∃U)
 inverseUniv q (Πⱼ A ▹ A₁) = Πⱼ inverseUniv (λ x → q (∃Π₁ x)) A ▹ inverseUniv (λ x → q (∃Π₂ x)) A₁
 inverseUniv q (univ x) = x

--- a/Definition/Typed/Consequences/NeTypeEq.agda
+++ b/Definition/Typed/Consequences/NeTypeEq.agda
@@ -30,6 +30,8 @@ neTypeEq (∘ₙ neT) (t∷A ∘ⱼ t∷A₁) (t∷B ∘ⱼ t∷B₁) with neTyp
           in  substTypeEq w (refl t∷A₁)
 neTypeEq (natrecₙ neT) (natrecⱼ x t∷A t∷A₁ t∷A₂) (natrecⱼ x₁ t∷B t∷B₁ t∷B₂) =
   refl (substType x₁ t∷B₂)
+neTypeEq (Emptyrecₙ neT) (Emptyrecⱼ x t∷A) (Emptyrecⱼ x₁ t∷B) =
+  refl x₁
 neTypeEq x (conv t∷A x₁) t∷B = let q = neTypeEq x t∷A t∷B
                                in  trans (sym x₁) q
 neTypeEq x t∷A (conv t∷B x₃) = let q = neTypeEq x t∷A t∷B

--- a/Definition/Typed/Consequences/Reduction.agda
+++ b/Definition/Typed/Consequences/Reduction.agda
@@ -18,6 +18,7 @@ whNorm′ : ∀ {A Γ l} ([A] : Γ ⊩⟨ l ⟩ A)
                 → ∃ λ B → Whnf B × Γ ⊢ A :⇒*: B
 whNorm′ (Uᵣ′ .⁰ 0<1 ⊢Γ) = U , Uₙ , idRed:*: (Uⱼ ⊢Γ)
 whNorm′ (ℕᵣ D) = ℕ , ℕₙ , D
+whNorm′ (Emptyᵣ D) = Empty , Emptyₙ , D
 whNorm′ (ne′ K D neK K≡K) = K , ne neK , D
 whNorm′ (Πᵣ′ F G D ⊢F ⊢G A≡A [F] [G] G-ext) = Π F ▹ G , Πₙ , D
 whNorm′ (emb 0<1 [A]) = whNorm′ [A]
@@ -33,6 +34,9 @@ whNormTerm′ (Uᵣ x) (Uₜ A d typeA A≡A [t]) = A , typeWhnf typeA , d
 whNormTerm′ (ℕᵣ x) (ℕₜ n d n≡n prop) =
   let natN = natural prop
   in  n , naturalWhnf natN , convRed:*: d (sym (subset* (red x)))
+whNormTerm′ (Emptyᵣ x) (Emptyₜ n d n≡n prop) =
+  let emptyN = empty prop
+  in  n , ne emptyN , convRed:*: d (sym (subset* (red x)))
 whNormTerm′ (ne (ne K D neK K≡K)) (neₜ k d (neNfₜ neK₁ ⊢k k≡k)) =
   k , ne neK₁ , convRed:*: d (sym (subset* (red D)))
 whNormTerm′ (Πᵣ′ F G D ⊢F ⊢G A≡A [F] [G] G-ext) (Πₜ f d funcF f≡f [f] [f]₁) =

--- a/Definition/Typed/EqRelInstance.agda
+++ b/Definition/Typed/EqRelInstance.agda
@@ -20,6 +20,7 @@ eqRelInstance = eqRel _⊢_≡_ _⊢_≡_∷_ _⊢_≡_∷_
                       conv conv wkEq wkEqTerm wkEqTerm
                       reduction reductionₜ
                       (refl ∘ᶠ Uⱼ) (refl ∘ᶠ ℕⱼ) (refl ∘ᶠ ℕⱼ)
+                      (refl ∘ᶠ Emptyⱼ) (refl ∘ᶠ Emptyⱼ)
                       Π-cong Π-cong (refl ∘ᶠ zeroⱼ) suc-cong
                       (λ x x₁ x₂ x₃ x₄ x₅ → η-eq x x₁ x₂ x₅)
-                      refl app-cong natrec-cong
+                      refl app-cong natrec-cong Emptyrec-cong

--- a/Definition/Typed/EqualityRelation.agda
+++ b/Definition/Typed/EqualityRelation.agda
@@ -104,6 +104,10 @@ record EqRelSet : Set₁ where
     ≅-ℕrefl   : ∀ {Γ} → ⊢ Γ → Γ ⊢ ℕ ≅ ℕ
     ≅ₜ-ℕrefl  : ∀ {Γ} → ⊢ Γ → Γ ⊢ ℕ ≅ ℕ ∷ U
 
+    -- Empty type reflexivity
+    ≅-Emptyrefl   : ∀ {Γ} → ⊢ Γ → Γ ⊢ Empty ≅ Empty
+    ≅ₜ-Emptyrefl  : ∀ {Γ} → ⊢ Γ → Γ ⊢ Empty ≅ Empty ∷ U
+
     -- Π-congurence
 
     ≅-Π-cong  : ∀ {F G H E Γ}
@@ -150,6 +154,12 @@ record EqRelSet : Set₁ where
              → Γ     ⊢ s ≅ s′ ∷ Π ℕ ▹ (F ▹▹ F [ suc (var 0) ]↑)
              → Γ     ⊢ n ~ n′ ∷ ℕ
              → Γ     ⊢ natrec F z s n ~ natrec F′ z′ s′ n′ ∷ F [ n ]
+
+    -- Empty recursion congurence
+    ~-Emptyrec : ∀ {n n′ F F′ Γ}
+             → Γ ⊢ F ≅ F′
+             → Γ     ⊢ n ~ n′ ∷ Empty
+             → Γ     ⊢ Emptyrec F n ~ Emptyrec F′ n′ ∷ F
 
 
   -- Composition of universe and generic equality compatibility

--- a/Definition/Typed/Weakening.agda
+++ b/Definition/Typed/Weakening.agda
@@ -55,6 +55,7 @@ mutual
      let ρA = U.wk ρ A
      in  ⊢ Δ → Γ ⊢ A → Δ ⊢ ρA
   wk ρ ⊢Δ (ℕⱼ ⊢Γ) = ℕⱼ ⊢Δ
+  wk ρ ⊢Δ (Emptyⱼ ⊢Γ) = Emptyⱼ ⊢Δ
   wk ρ ⊢Δ (Uⱼ ⊢Γ) = Uⱼ ⊢Δ
   wk ρ ⊢Δ (Πⱼ F ▹ G) = let ρF = wk ρ ⊢Δ F
                        in  Πⱼ ρF ▹ (wk (lift ρ) (⊢Δ ∙ ρF) G)
@@ -65,6 +66,7 @@ mutual
              ρt = U.wk ρ t
          in ⊢ Δ → Γ ⊢ t ∷ A → Δ ⊢ ρt ∷ ρA
   wkTerm ρ ⊢Δ (ℕⱼ ⊢Γ) = ℕⱼ ⊢Δ
+  wkTerm ρ ⊢Δ (Emptyⱼ ⊢Γ) = Emptyⱼ ⊢Δ
   wkTerm ρ ⊢Δ (Πⱼ F ▹ G) = let ρF = wkTerm ρ ⊢Δ F
                           in  Πⱼ ρF ▹ (wkTerm (lift ρ) (⊢Δ ∙ univ ρF) G)
   wkTerm ρ ⊢Δ (var ⊢Γ x) = var ⊢Δ (wkIndex ρ ⊢Δ x)
@@ -83,6 +85,8 @@ mutual
                                 (wk-β-natrec ρ G)
                                 (wkTerm [ρ] ⊢Δ ⊢s))
                       (wkTerm [ρ] ⊢Δ ⊢n))
+  wkTerm {Δ = Δ} {ρ = ρ} [ρ] ⊢Δ (Emptyrecⱼ {A = A} {e = e} ⊢A ⊢e) =
+    (Emptyrecⱼ (wk [ρ] ⊢Δ ⊢A) (wkTerm [ρ] ⊢Δ ⊢e))
   wkTerm ρ ⊢Δ (conv t A≡B) = conv (wkTerm ρ ⊢Δ t) (wkEq ρ ⊢Δ A≡B)
 
   wkEq : ∀ {Γ Δ A B ρ} → ρ ∷ Δ ⊆ Γ →
@@ -165,6 +169,10 @@ mutual
                          (PE.subst (λ x → Δ ⊢ U.wk ρ s ∷ x)
                                    (wk-β-natrec _ F)
                                    (wkTerm [ρ] ⊢Δ ⊢s)))
+  wkEqTerm {Δ = Δ} {ρ = ρ} [ρ] ⊢Δ (Emptyrec-cong {A = A} {A' = A'} {e = e} {e' = e'}
+                                  A≡A' e≡e') =
+    (Emptyrec-cong (wkEq [ρ] ⊢Δ A≡A')
+      (wkEqTerm [ρ] ⊢Δ e≡e'))
 
 mutual
   wkRed : ∀ {Γ Δ A B ρ} → ρ ∷ Δ ⊆ Γ →
@@ -219,6 +227,9 @@ mutual
                          (PE.subst (λ x → Δ ⊢ U.wk ρ s ∷ x)
                                    (wk-β-natrec ρ F)
                                    (wkTerm [ρ] ⊢Δ ⊢s)))
+  wkRedTerm {Δ = Δ} {ρ = ρ} [ρ] ⊢Δ (Emptyrec-subst {A = A} ⊢A n⇒n′) =
+    (Emptyrec-subst (wk [ρ] ⊢Δ ⊢A)
+                    (wkRedTerm [ρ] ⊢Δ n⇒n′))
 
 wkRed* : ∀ {Γ Δ A B ρ} → ρ ∷ Δ ⊆ Γ →
            let ρA = U.wk ρ A

--- a/Definition/Untyped.agda
+++ b/Definition/Untyped.agda
@@ -31,9 +31,19 @@ record GenT (A : Set) : Set where
     l : Nat
     t : A
 
+data Kind : Set where
+  Ukind : Kind
+  Pikind : Kind
+  Natkind : Kind
+  Lamkind : Kind
+  Appkind : Kind
+  Zerokind : Kind
+  Suckind : Kind
+  Natreckind : Kind
+
 data Term : Set where
   var : (x : Nat) → Term
-  gen : (x : Nat) (c : List (GenT Term)) → Term
+  gen : (k : Kind) (c : List (GenT Term)) → Term
 
 -- The Grammar of our language.
 
@@ -43,33 +53,35 @@ data Term : Set where
 
 -- Type constructors.
 U      : Term                     -- Universe.
-U = gen 0 []
+U = gen Ukind []
+
+pattern Univ u = gen (Ukind u) []
 
 Π_▹_   : (A B : Term)     → Term  -- Dependent function type (B is a binder).
-Π A ▹ B = gen 1 (⟦ 0 , A ⟧ ∷ ⟦ 1 , B ⟧ ∷ [])
+Π A ▹ B = gen Pikind (⟦ 0 , A ⟧ ∷ ⟦ 1 , B ⟧ ∷ [])
 
 ℕ      : Term                     -- Type of natural numbers.
-ℕ = gen 2 []
+ℕ = gen Natkind []
 
 -- Lambda-calculus.
 -- var    : (x : Nat)        → Term  -- Variable (de Bruijn index).
 -- var = var
 
 lam    : (t : Term)       → Term  -- Function abstraction (binder).
-lam t = gen 3 (⟦ 1 , t ⟧ ∷ [])
+lam t = gen Lamkind (⟦ 1 , t ⟧ ∷ [])
 
 _∘_    : (t u : Term)     → Term  -- Application.
-t ∘ u = gen 4 (⟦ 0 , t ⟧ ∷ ⟦ 0 , u ⟧ ∷ [])
+t ∘ u = gen Appkind (⟦ 0 , t ⟧ ∷ ⟦ 0 , u ⟧ ∷ [])
 
 -- Introduction and elimination of natural numbers.
 zero   : Term                     -- Natural number zero.
-zero = gen 5 []
+zero = gen Zerokind []
 
 suc    : (t : Term)       → Term  -- Successor.
-suc t = gen 6 (⟦ 0 , t ⟧ ∷ [])
+suc t = gen Suckind (⟦ 0 , t ⟧ ∷ [])
 
 natrec : (A t u v : Term) → Term  -- Recursor (A is a binder).
-natrec A t u v = gen 7 (⟦ 1 , A ⟧ ∷ ⟦ 0 , t ⟧ ∷ ⟦ 0 , u ⟧ ∷ ⟦ 0 , v ⟧ ∷ [])
+natrec A t u v = gen Natreckind (⟦ 1 , A ⟧ ∷ ⟦ 0 , t ⟧ ∷ ⟦ 0 , u ⟧ ∷ ⟦ 0 , v ⟧ ∷ [])
 
 
 -- Injectivity of term constructors w.r.t. propositional equality.


### PR DESCRIPTION
I did this to introduce myself to this development.

Because Empty and nat are both inductive types the similarity produces a lot of slightly modified copy-pasted cases. In some places eg `natrec x x1 x2 x3` became `Emptyrec x x3` as I removed the middle variable, maybe I should cleanup the indexing.

The most difficult change was `Definition/LogicalRelation/Substitution/Introductions/Emptyrec.agda` (starting from the natrec version). (Some of that was because it was the place where I had to get over some Agda inexperience.) Also, `natrec` is a dependent eliminator but I made `Emptyrec` non dependent (there is no point for Empty) so there is a significant amount of messing with substitutions which got removed.